### PR TITLE
bump console to v0.0.5 for firefox patches

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,9 @@ WORKDIR /var/www/html/api
 # Copy application files
 COPY --chown=www-data:www-data api ./
 RUN chown -R www-data:www-data /var/www/html/api
+RUN chown -R www-data:www-data /var/www/html/api/bootstrap/cache
+RUN chmod -R 755 /var/www/html/api/storage
+RUN chmod -R 755 /var/www/html/api/bootstrap/cache
 USER www-data
 
 # Install Composer dependencies


### PR DESCRIPTION
### What change does this PR introduce?

* Patches issues on firefox by utilizing `event.preventDefault()` on element events which trigger server requests

### Why was this change needed?

* Patches some issues experienced on firefox

