### PR TITLE
updated api to use `fleetbase/core-api#v1.0.6-alpha`

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
-        "fleetbase/core-api": "^1.0.5-alpha",
+        "fleetbase/core-api": "^1.0.6-alpha",
         "fleetbase/fleetops-api": "^1.0.2-alpha",
         "fleetbase/storefront-api": "^1.0.1-alpha",
         "fruitcake/laravel-cors": "^2.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "107abf06202c144f113f126fcfd5b74b",
+    "content-hash": "0c48f488648424e57133c3479ecf9d2b",
     "packages": [
         {
             "name": "aloha/twilio",
@@ -2002,16 +2002,16 @@
         },
         {
             "name": "fleetbase/core-api",
-            "version": "1.0.5-alpha",
+            "version": "1.0.6-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fleetbase/core-api.git",
-                "reference": "674dec087c0f18d45b1d4fef3a0ed1d02fa50378"
+                "reference": "20890b9623c0ea8aa416d711fb45c15738025b6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fleetbase/core-api/zipball/674dec087c0f18d45b1d4fef3a0ed1d02fa50378",
-                "reference": "674dec087c0f18d45b1d4fef3a0ed1d02fa50378",
+                "url": "https://api.github.com/repos/fleetbase/core-api/zipball/20890b9623c0ea8aa416d711fb45c15738025b6f",
+                "reference": "20890b9623c0ea8aa416d711fb45c15738025b6f",
                 "shasum": ""
             },
             "require": {
@@ -2085,7 +2085,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fleetbase/core-api/issues",
-                "source": "https://github.com/fleetbase/core-api/tree/v1.0.5-alpha"
+                "source": "https://github.com/fleetbase/core-api/tree/v1.0.6-alpha"
             },
             "funding": [
                 {
@@ -2093,7 +2093,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-09T04:00:31+00:00"
+            "time": "2023-06-09T04:36:21+00:00"
         },
         {
             "name": "fleetbase/fleetops-api",


### PR DESCRIPTION
* Updated api to use `fleetbase/core-api#v1.0.6-alpha`
* Hotfixes `mergeConfigFromSettings()` only execute if migrations completed/ settings table exists