### PR TITLE
Use the external httpd container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,5 +101,4 @@ CMD ["php", "artisan", "queue:work", "sqs"]
 # Application stage
 FROM base as app
 ENTRYPOINT ["/sbin/ssm-parent", "-c", ".ssm-parent.yaml", "run", "--", "docker-php-entrypoint"]
-EXPOSE 80
-CMD ["/startup.sh"]
+CMD ["php-fpm"]


### PR DESCRIPTION
Changes the hosted app Docker stage to not use the internal nginx.

Instead there will be another container linked to the app.
