### PR TITLE
Hotfix s3deploy dockerfile

### DIFF
--- a/.s3deploy.yml
+++ b/.s3deploy.yml
@@ -7,7 +7,11 @@ routes:
     headers:
       Cache-Control: "max-age=600, no-transform, public"
     gzip: false
-  - route: "^.+\\.(html|xml|json)$"
+  - route: "^.+\\.(xml|json)$"
+    headers:
+      Cache-Control: "max-age=600, no-transform, public"
+    gzip: true
+  - route: "^.+\\.(html)$"
     headers:
       Cache-Control: "public, max-age=0, must-revalidate"
     gzip: true

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build Stage ----
-FROM node:16.20-alpine AS builder
+FROM node:18.15.0-alpine AS builder
 
 # Set the working directory in the container to /app
 WORKDIR /app


### PR DESCRIPTION
### What change does this PR introduce?

- Adds correct `Cache-Control` header for json and xml files
- Upgrades node in the console dockerfile from v16 to v18
