### PR TITLE
Add command to link public storage disk

### DIFF
--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -37,3 +37,6 @@ php artisan registry:init
 
 # Restart octane
 # php artisan octane:reload
+
+# Link public disk
+php artisan storage:link


### PR DESCRIPTION
### What change does this PR introduce?

this allows for the `public` folder inside the `api/storage/app/public` to be accessible
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

this is needed because otherwise when you create an order with proof of photo
and you upload the photo via the navigator app,
you cant actually view the picture, you just get a 400 error

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
