### PR TITLE
fix(console): enable runtime config loading in production by default

### DIFF
--- a/console/config/environment.js
+++ b/console/config/environment.js
@@ -23,7 +23,7 @@ module.exports = function (environment) {
         APP: {
             autoboot: true,
             extensions: asArray(getenv('EXTENSIONS')),
-            disableRuntimeConfig: toBoolean(getenv('DISABLE_RUNTIME_CONFIG', environment === 'production')),
+            disableRuntimeConfig: toBoolean(getenv('DISABLE_RUNTIME_CONFIG', false)),
         },
 
         API: {


### PR DESCRIPTION
### Problem
When using the official Docker images with `docker-install.sh` with default settings, the console makes API requests to `http://localhost` instead of `http://localhost:8000`.

### Root Cause  
In `console/config/environment.js`, the `disableRuntimeConfig` option defaults to `true` in production:
disableRuntimeConfig: toBoolean(getenv('DISABLE_RUNTIME_CONFIG', environment === 'production')),

This prevents the fleetbase.config.json file from being loaded, even though it's mounted as a volume in docker-compose.yml.

### Solution
Change the default to false so runtime config is always loaded unless explicitly disabled via DISABLE_RUNTIME_CONFIG=true.

### Testing
Run ./scripts/docker-install.sh
Access http://localhost:4200
Verify API calls go to http://localhost:8000 instead of http://localhost