### PR TITLE
fix(scripts): replace unicode quotes with ASCII in docker-install.sh

### DIFF
--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -125,7 +125,7 @@ docker compose up -d
 DB_SERVICE="database"     # ← change if your docker‑compose uses a different name
 DB_WAIT_TIMEOUT=60        # seconds
 
-echo "⏳  Waiting for “$DB_SERVICE” to become ready (timeout: ${DB_WAIT_TIMEOUT}s)…"
+echo "⏳  Waiting for $DB_SERVICE to become ready (timeout: ${DB_WAIT_TIMEOUT}s)..."
 DB_CONTAINER=$(docker compose ps -q "$DB_SERVICE")
 
 if [ -z "$DB_CONTAINER" ]; then


### PR DESCRIPTION
### Problem
Running `./scripts/docker-install.sh` fails with:
```
./scripts/docker-install.sh: line 128: DB_SERVICE�: unbound variable
```
### Root Cause
Line 128 contains typographic curly quotes (`"` and `"`) instead of standard ASCII double quotes (`"`):

#### Before (broken)
`echo "⏳  Waiting for "$DB_SERVICE" to become ready..."`

#### After (fixed)  
`echo "⏳  Waiting for $DB_SERVICE to become ready..."`

The curly quotes are not recognized by bash as string delimiters, causing the variable to be interpreted incorrectly.

### Solution
Replace unicode typographic quotes with ASCII quotes and unicode ellipsis (…) with ASCII dots (...).
