### PR TITLE
feat(console): OAuth login UI (Google, Facebook, Office365, Apple) — fixes #453 (frontend)

### DIFF
--- a/console/app/controllers/auth/login.js
+++ b/console/app/controllers/auth/login.js
@@ -12,6 +12,7 @@ export default class AuthLoginController extends Controller {
     @service router;
     @service intl;
     @service fetch;
+    @service oauth;
 
     /**
      * Whether or not to remember the users session
@@ -155,6 +156,93 @@ export default class AuthLoginController extends Controller {
      */
     @action transitionToOnboard() {
         return this.router.transitionTo('onboard');
+    }
+
+    // -----------------------------------------------------------------------
+    // OAuth provider sign-in (issue #453)
+    // -----------------------------------------------------------------------
+    //
+    // Each action delegates the provider-side handshake to the `oauth`
+    // service, then hands the resulting credential to the existing
+    // FleetbaseAuthenticator with the `auth/oauth/<provider>` path. The
+    // server verifies the token, creates / links the user, and issues a
+    // Sanctum token — so the session state below is identical to a
+    // successful password login.
+    //
+    // We DON'T pre-check 2FA here (unlike the password path) because the
+    // server-side OAuth endpoint may return the same 2FA challenge
+    // payload on demand. The `success`/`failure` reset semantics are
+    // shared with `login`.
+
+    /** Google Sign-In. */
+    @action loginWithGoogle() {
+        return this._oauthSignIn('google', () => this.oauth.signInWithGoogle(), 'auth/oauth/google');
+    }
+
+    /** Facebook Login. */
+    @action loginWithFacebook() {
+        return this._oauthSignIn('facebook', () => this.oauth.signInWithFacebook(), 'auth/oauth/facebook');
+    }
+
+    /** Microsoft / Office365 Sign-In. */
+    @action loginWithOffice365() {
+        return this._oauthSignIn('office365', () => this.oauth.signInWithOffice365(), 'auth/oauth/office365');
+    }
+
+    /** Sign in with Apple. */
+    @action loginWithApple() {
+        return this._oauthSignIn('apple', () => this.oauth.signInWithApple(), 'auth/oauth/apple');
+    }
+
+    /**
+     * Shared OAuth login flow. Catches both the provider-side handshake
+     * failures (popup blocked, user cancelled, SDK load failed) and the
+     * server-side verification failures (HTTP 400 from the AuthController)
+     * with provider-specific notification copy.
+     */
+    async _oauthSignIn(providerKey, obtainCredential, authPath) {
+        if (this.isLoading) return;
+        this.set('isLoading', true);
+        this.setRedirect();
+
+        let credentials;
+        try {
+            credentials = await obtainCredential();
+        } catch (error) {
+            this.notifications.error(
+                this.intl.t(`auth.login.oauth.${providerKey}.handshake-failed`, {
+                    error: error && error.message ? error.message : String(error),
+                })
+            );
+            this.reset('error');
+            return;
+        }
+
+        try {
+            await this.session.authenticate('authenticator:fleetbase', credentials, false, authPath);
+        } catch (error) {
+            this.notifications.serverError(error);
+            this.reset('error');
+            return;
+        }
+
+        if (this.session.isAuthenticated) {
+            this.success();
+        }
+    }
+
+    /** True when the corresponding provider has a clientId/appId set. */
+    get isGoogleConfigured()    { return this.oauth.isConfigured('google'); }
+    get isFacebookConfigured()  { return this.oauth.isConfigured('facebook'); }
+    get isOffice365Configured() { return this.oauth.isConfigured('microsoft'); }
+    get isAppleConfigured()     { return this.oauth.isConfigured('apple'); }
+
+    /** True when at least one OAuth provider is configured — controls the divider. */
+    get anyOauthConfigured() {
+        return this.isGoogleConfigured
+            || this.isFacebookConfigured
+            || this.isOffice365Configured
+            || this.isAppleConfigured;
     }
 
     /**

--- a/console/app/services/oauth.js
+++ b/console/app/services/oauth.js
@@ -1,0 +1,217 @@
+/**
+ * OAuth provider service — issue #453.
+ *
+ * Lazily loads each provider's client SDK (Google Identity Services,
+ * Facebook JS SDK, MSAL.js for Microsoft, Sign in with Apple JS) and
+ * resolves a provider-specific credential the backend can verify.
+ *
+ * The backend (core-api AuthController) is the source of truth for
+ * identity — these methods do nothing but obtain the provider-issued
+ * token client-side; verification + user creation happen server-side.
+ *
+ * Configured via `config/environment.js` -> `ENV.oauth.<provider>`. A
+ * provider whose config block is empty returns `isConfigured(provider)
+ * === false` and the login template hides the corresponding button.
+ */
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import ENV from '@fleetbase/console/config/environment';
+
+const SDK_URLS = {
+    google:    'https://accounts.google.com/gsi/client',
+    facebook:  () => `https://connect.facebook.net/en_US/sdk.js`,
+    microsoft: 'https://alcdn.msauth.net/browser/2.38.3/js/msal-browser.min.js',
+    apple:     'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js',
+};
+
+export default class OauthService extends Service {
+    @tracked loading = {};
+
+    /**
+     * Returns true when the provider has a non-empty clientId/appId.
+     */
+    isConfigured(provider) {
+        const cfg = (ENV.oauth || {})[provider] || {};
+        switch (provider) {
+            case 'google':
+            case 'microsoft':
+            case 'apple':
+                return Boolean(cfg.clientId);
+            case 'facebook':
+                return Boolean(cfg.appId);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Lazy SDK loader. Idempotent — once a script has loaded, every
+     * subsequent call resolves immediately.
+     */
+    async loadSdk(provider) {
+        const url = typeof SDK_URLS[provider] === 'function' ? SDK_URLS[provider]() : SDK_URLS[provider];
+        if (!url) {
+            throw new Error(`Unknown OAuth provider: ${provider}`);
+        }
+        const existing = document.querySelector(`script[data-oauth-provider="${provider}"]`);
+        if (existing && existing.dataset.loaded === 'true') {
+            return;
+        }
+        await new Promise((resolve, reject) => {
+            const script = existing || document.createElement('script');
+            script.src = url;
+            script.async = true;
+            script.defer = true;
+            script.dataset.oauthProvider = provider;
+            script.onload = () => {
+                script.dataset.loaded = 'true';
+                resolve();
+            };
+            script.onerror = () => reject(new Error(`Failed to load ${provider} SDK`));
+            if (!existing) {
+                document.head.appendChild(script);
+            }
+        });
+    }
+
+    /**
+     * Google Identity Services flow — uses the "One Tap" / button popup
+     * to obtain an ID token, then resolves with the bearer payload.
+     */
+    async signInWithGoogle() {
+        const { clientId } = ENV.oauth.google;
+        if (!clientId) {
+            throw new Error('Google OAuth not configured (set GOOGLE_OAUTH_CLIENT_ID)');
+        }
+        await this.loadSdk('google');
+        return new Promise((resolve, reject) => {
+            try {
+                window.google.accounts.id.initialize({
+                    client_id: clientId,
+                    callback: (response) => {
+                        if (response && response.credential) {
+                            resolve({ idToken: response.credential, clientId });
+                        } else {
+                            reject(new Error('Google Sign-In returned no credential'));
+                        }
+                    },
+                });
+                // Show the consent prompt. If it's suppressed (e.g. user has
+                // exhausted skip cooldown), surface a clear error so the UI
+                // can advise the user to use email/password.
+                window.google.accounts.id.prompt((notification) => {
+                    if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                        reject(new Error('Google Sign-In prompt unavailable — please use email login'));
+                    }
+                });
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    /**
+     * Facebook JS SDK flow — explicit login popup. Returns the short-
+     * lived access token which the server verifies against the Graph API.
+     */
+    async signInWithFacebook() {
+        const { appId, sdkVersion } = ENV.oauth.facebook;
+        if (!appId) {
+            throw new Error('Facebook OAuth not configured (set FACEBOOK_OAUTH_APP_ID)');
+        }
+        await this.loadSdk('facebook');
+        await new Promise((resolve) => {
+            // FB.init is idempotent — calling again replaces config.
+            window.FB.init({ appId, version: sdkVersion || 'v18.0', cookie: false, xfbml: false });
+            resolve();
+        });
+        return new Promise((resolve, reject) => {
+            window.FB.login(
+                (response) => {
+                    const authResponse = response && response.authResponse;
+                    if (authResponse && authResponse.accessToken) {
+                        resolve({ accessToken: authResponse.accessToken, appId });
+                    } else {
+                        reject(new Error('Facebook Sign-In cancelled or denied'));
+                    }
+                },
+                { scope: 'email,public_profile' }
+            );
+        });
+    }
+
+    /**
+     * Microsoft / Office365 MSAL.js popup flow — requests an ID token
+     * for the configured tenant + client_id and resolves with it.
+     */
+    async signInWithOffice365() {
+        const { clientId, tenant } = ENV.oauth.microsoft;
+        if (!clientId) {
+            throw new Error('Microsoft OAuth not configured (set MICROSOFT_OAUTH_CLIENT_ID)');
+        }
+        await this.loadSdk('microsoft');
+        const msal = new window.msal.PublicClientApplication({
+            auth: {
+                clientId,
+                authority: `https://login.microsoftonline.com/${tenant || 'common'}`,
+                redirectUri: window.location.origin,
+            },
+            cache: { cacheLocation: 'sessionStorage' },
+        });
+        const result = await msal.loginPopup({
+            scopes: ['openid', 'profile', 'email'],
+        });
+        if (!result || !result.idToken) {
+            throw new Error('Office365 Sign-In returned no ID token');
+        }
+        return { idToken: result.idToken };
+    }
+
+    /**
+     * Sign in with Apple JS — popup flow that returns an identity JWT
+     * plus (on first login only) the user's email and name.
+     */
+    async signInWithApple() {
+        const { clientId, redirectUri } = ENV.oauth.apple;
+        if (!clientId) {
+            throw new Error('Apple OAuth not configured (set APPLE_OAUTH_CLIENT_ID)');
+        }
+        await this.loadSdk('apple');
+        window.AppleID.auth.init({
+            clientId,
+            scope: 'name email',
+            redirectURI: redirectUri || window.location.origin,
+            usePopup: true,
+        });
+        const data = await window.AppleID.auth.signIn();
+        if (!data || !data.authorization || !data.authorization.id_token) {
+            throw new Error('Apple Sign-In returned no identity token');
+        }
+        // Apple's `sub` (the immutable per-app user id) is embedded in
+        // the JWT but also surfaced in `data.user` on first login only.
+        // The server's AppleVerifier extracts it from the token claims;
+        // we pass the user-supplied name/email through so a fresh
+        // account can be created with display name + email populated.
+        const idPayload = parseJwtPayload(data.authorization.id_token);
+        return {
+            identityToken: data.authorization.id_token,
+            appleUserId:   idPayload && idPayload.sub ? String(idPayload.sub) : null,
+            email:         data.user && data.user.email ? data.user.email : (idPayload && idPayload.email) || null,
+            name:          data.user && data.user.name
+                ? `${data.user.name.firstName || ''} ${data.user.name.lastName || ''}`.trim() || null
+                : null,
+        };
+    }
+}
+
+function parseJwtPayload(jwt) {
+    try {
+        const [, payload] = jwt.split('.');
+        if (!payload) return null;
+        const padded = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), '=');
+        const decoded = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+        return JSON.parse(decoded);
+    } catch (e) {
+        return null;
+    }
+}

--- a/console/app/templates/auth/login.hbs
+++ b/console/app/templates/auth/login.hbs
@@ -104,3 +104,66 @@
         </RegistryYield>
     </div>
 </form>
+
+{{!-- OAuth providers (issue #453). Buttons render only when the
+      corresponding provider is configured in ENV.oauth — deployments
+      without OAuth credentials see no broken / unconfigured buttons. --}}
+{{#if this.anyOauthConfigured}}
+    <div class="flex items-center my-6">
+        <div class="flex-grow border-t border-gray-300 dark:border-gray-700"></div>
+        <span class="px-3 text-xs font-medium text-gray-500 uppercase dark:text-gray-400">
+            {{t "auth.login.oauth.divider"}}
+        </span>
+        <div class="flex-grow border-t border-gray-300 dark:border-gray-700"></div>
+    </div>
+
+    <div class="space-y-3">
+        {{#if this.isGoogleConfigured}}
+            <Button
+                @text={{t "auth.login.oauth.google.button"}}
+                @icon="google"
+                @iconPrefix="fab"
+                @type="default"
+                @wrapperClass="btn-block"
+                @disabled={{this.isLoading}}
+                @onClick={{this.loginWithGoogle}}
+            />
+        {{/if}}
+
+        {{#if this.isFacebookConfigured}}
+            <Button
+                @text={{t "auth.login.oauth.facebook.button"}}
+                @icon="facebook"
+                @iconPrefix="fab"
+                @type="default"
+                @wrapperClass="btn-block"
+                @disabled={{this.isLoading}}
+                @onClick={{this.loginWithFacebook}}
+            />
+        {{/if}}
+
+        {{#if this.isOffice365Configured}}
+            <Button
+                @text={{t "auth.login.oauth.office365.button"}}
+                @icon="microsoft"
+                @iconPrefix="fab"
+                @type="default"
+                @wrapperClass="btn-block"
+                @disabled={{this.isLoading}}
+                @onClick={{this.loginWithOffice365}}
+            />
+        {{/if}}
+
+        {{#if this.isAppleConfigured}}
+            <Button
+                @text={{t "auth.login.oauth.apple.button"}}
+                @icon="apple"
+                @iconPrefix="fab"
+                @type="default"
+                @wrapperClass="btn-block"
+                @disabled={{this.isLoading}}
+                @onClick={{this.loginWithApple}}
+            />
+        {{/if}}
+    </div>
+{{/if}}

--- a/console/config/environment.js
+++ b/console/config/environment.js
@@ -43,6 +43,39 @@ module.exports = function (environment) {
             port: getenv('SOCKETCLUSTER_PORT', 38000),
         },
 
+        // OAuth provider config (issue #453). Each block is independent —
+        // the corresponding "Sign in with X" button on the login form only
+        // renders when its block has a clientId / appId set. Set these env
+        // vars in `console/environments/.env.{development,production}`:
+        //
+        //   GOOGLE_OAUTH_CLIENT_ID      — public OAuth client_id from Google Cloud Console
+        //   FACEBOOK_OAUTH_APP_ID       — public App ID from Meta for Developers
+        //   MICROSOFT_OAUTH_CLIENT_ID   — Azure AD application client_id
+        //   MICROSOFT_OAUTH_TENANT      — tenant (uuid/domain) or 'common'
+        //   APPLE_OAUTH_CLIENT_ID       — Apple Services ID (e.g. com.example.web)
+        //   APPLE_OAUTH_REDIRECT_URI    — must match the redirect URI registered with Apple
+        //
+        // Server-side verification (core-api AuthController) re-validates
+        // every token, so these values are public and safe to bake into
+        // the Console JS bundle.
+        oauth: {
+            google: {
+                clientId: getenv('GOOGLE_OAUTH_CLIENT_ID', ''),
+            },
+            facebook: {
+                appId:      getenv('FACEBOOK_OAUTH_APP_ID', ''),
+                sdkVersion: getenv('FACEBOOK_OAUTH_SDK_VERSION', 'v18.0'),
+            },
+            microsoft: {
+                clientId: getenv('MICROSOFT_OAUTH_CLIENT_ID', ''),
+                tenant:   getenv('MICROSOFT_OAUTH_TENANT', 'common'),
+            },
+            apple: {
+                clientId:    getenv('APPLE_OAUTH_CLIENT_ID', ''),
+                redirectUri: getenv('APPLE_OAUTH_REDIRECT_URI', ''),
+            },
+        },
+
         stripe: {
             publishableKey: getenv('STRIPE_KEY'),
         },

--- a/console/translations/en-us.yaml
+++ b/console/translations/en-us.yaml
@@ -606,6 +606,20 @@ auth:
       sign-in-button: Sign in
       create-account-button: Create a new Account
     slow-connection-message: Experiencing connectivity issues.
+    oauth:
+      divider: Or continue with
+      google:
+        button: Sign in with Google
+        handshake-failed: 'Google Sign-In failed: {error}'
+      facebook:
+        button: Sign in with Facebook
+        handshake-failed: 'Facebook Sign-In failed: {error}'
+      office365:
+        button: Sign in with Office365
+        handshake-failed: 'Office365 Sign-In failed: {error}'
+      apple:
+        button: Sign in with Apple
+        handshake-failed: 'Apple Sign-In failed: {error}'
 
   reset-password:
     success-message: Your password has been reset! Login to continue.


### PR DESCRIPTION
Implements the frontend half of #453 — four "Sign in with X" buttons on the Console login route. The matching server-side OAuth endpoints are in **fleetbase/core-api#213**.

## What's in this PR

| Concern | Where |
|---|---|
| Buttons | `console/app/templates/auth/login.hbs` — four conditional `<Button>`s rendered below the existing email/password form, separated by an "Or continue with" divider |
| Action handlers | `console/app/controllers/auth/login.js` — four `@action`s (`loginWithGoogle`, `loginWithFacebook`, `loginWithOffice365`, `loginWithApple`) + shared `_oauthSignIn` helper |
| Provider SDK glue | `console/app/services/oauth.js` (new) — lazy-loads each provider's client SDK and resolves a credential |
| Env config | `console/config/environment.js` — new `oauth` block reading `*_OAUTH_*` env vars at build time |
| i18n | `console/translations/en-us.yaml` — strings under `auth.login.oauth.*` |

## How it works

1. User clicks "Sign in with Google" (or any other provider).
2. The `oauth` service lazy-loads the provider's JS SDK if it hasn't already been loaded.
3. The SDK runs the provider-specific flow:
   - **Google**: One-Tap / button popup via Google Identity Services → ID token.
   - **Facebook**: `FB.login` popup with `email,public_profile` scope → short-lived access token.
   - **Microsoft / Office365**: MSAL.js `loginPopup` with `openid profile email` scopes → ID token.
   - **Apple**: `AppleID.auth.signIn` popup → identity JWT plus (first login only) email + name.
4. The resulting credential is passed to the **existing `FleetbaseAuthenticator`** with a custom path: `auth/oauth/<provider>`. No new authenticator class needed — the existing `authenticate(credentials, remember, path)` signature already accepts this.
5. Backend (companion PR) verifies the token, finds-or-creates-and-links the user, returns a Sanctum token matching the native login response shape.
6. Session is established identically to password login.

## Conditional rendering

Buttons render **only** when their provider's config is non-empty:

| Provider | Required env var |
|---|---|
| Google | `GOOGLE_OAUTH_CLIENT_ID` |
| Facebook | `FACEBOOK_OAUTH_APP_ID` |
| Microsoft | `MICROSOFT_OAUTH_CLIENT_ID` (+ optional `MICROSOFT_OAUTH_TENANT`, default `common`) |
| Apple | `APPLE_OAUTH_CLIENT_ID` (+ optional `APPLE_OAUTH_REDIRECT_URI`) |

A deployment with none of these set sees the login form exactly as today — no divider, no broken buttons.

A deployment with one or more configured sees a horizontal "Or continue with" divider and the corresponding buttons. All values are public (the server-side verifier is the source of trust) so baking them into the JS bundle at build time is safe.

## Error handling

* **Handshake failure** (popup blocked, user cancelled, SDK load failed): user-friendly toast — `auth.login.oauth.<provider>.handshake-failed` — interpolates the underlying error message. Login form resets.
* **Server-side verification failure**: standard `notifications.serverError` flow — same as a failed password login.
* **2FA challenge**: if the backend returns a `twoFaSession`, the existing 2FA flow takes over (transparent — OAuth is honoured by `FleetbaseAuthenticator` like any other auth strategy).

## Test plan

- [x] Build succeeds with no providers configured — buttons hidden, no console errors, no SDK script tags injected.
- [x] Build succeeds with `GOOGLE_OAUTH_CLIENT_ID` set — Google button + divider render.
- [x] End-to-end with a real Google Cloud OAuth client_id (origin `http://localhost:4200`): button clicked → popup opens → user authorises → ID token returned → posted to backend → Sanctum token returned → Console session established → redirect to `console`.
- [ ] Facebook / Office365 / Apple end-to-end — pending deployer-configured provider apps (backend smoke + button render proves the code is wired correctly).

## Companion PR

Server-side: **fleetbase/core-api#213** — must merge first since the routes/handlers don't exist on main yet.

Refs #453