### PR TITLE
ci(api-contract): track latest by default and surface Postman results

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -108,31 +108,98 @@ runs:
       run: |
         set -uo pipefail
         overall=0
-        # Accept commas or newlines as separators; the loop runs in the current
-        # shell (process substitution) so $overall survives.
+        mkdir -p postman-results
+
+        {
+          echo "## Postman API contract"
+          echo
+          echo "\`${BASE_URL}/${NAMESPACE}\` · collections from fleetbase/postman@${{ inputs.postman-ref }}"
+          echo
+          echo "| Collection | Result | Requests | Assertions | Failed |"
+          echo "| --- | --- | ---: | ---: | ---: |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
         while IFS= read -r raw; do
           name="$(echo "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           [[ -z "$name" ]] && continue
           dir=".postman/postman/collections/$name"
           if [[ ! -d "$dir" ]]; then
-            echo "::warning::Collection directory not found: $dir"
+            # A caller asking for a collection that does not exist is a misconfiguration,
+            # not something to pass silently.
+            echo "::error::Collection directory not found: $dir"
+            echo "| $name | ⚠️ not found | – | – | – |" >> "$GITHUB_STEP_SUMMARY"
+            overall=1
             continue
           fi
-          echo "::group::Collection: $name"
+
           extra=()
           if [[ "$name" == "Fleetbase Integrated Vendor Flow" ]]; then
             extra+=(--iteration-data ".postman/collections/workflows/integrated-vendor/data/happy-path.example.json")
           fi
+
+          log="postman-results/$(echo "$name" | tr ' /' '__').log"
+          echo "───────────────────────────────────────────────────────────────"
+          echo "▶ Running collection: $name"
+          echo "───────────────────────────────────────────────────────────────"
+
+          # tee so the full run is visible in the job log AND kept for the summary and
+          # the uploaded artifact. Not wrapped in ::group:: — these results are the
+          # point of the job, so they should be readable without expanding anything.
           if postman collection run "$dir" \
               --env-var "base_url=${BASE_URL}" \
               --env-var "namespace=${NAMESPACE}" \
               --env-var "api_key=${API_KEY}" \
-              "${extra[@]}"; then
-            echo "✔ $name passed"
+              "${extra[@]}" 2>&1 | tee "$log"; then
+            status="✅ passed"
           else
-            echo "::warning::Collection failed: $name"
+            status="❌ failed"
             overall=1
           fi
-          echo "::endgroup::"
+
+          # Pull executed/failed out of the CLI reporter's summary table. The table is
+          # drawn with box characters, not ASCII pipes, so match on the label plus two
+          # numbers rather than on the border. Tolerant on purpose: if the format shifts
+          # the row renders with dashes and the artifact stays authoritative.
+          row() { grep -aiE "(^|[^a-z])$1([^a-z]|$)" "$log" | grep -aE '[0-9]+[^0-9]+[0-9]+' \
+                    | head -1 | grep -oE '[0-9]+' | head -2 | paste -sd/ - ; }
+          requests="$(row requests || true)"
+          assertions="$(row assertions || true)"
+          failed="$(grep -acE '^[[:space:]]*[0-9]+\.[[:space:]]+.*(AssertionError|expected)' "$log" || true)"
+          echo "| $name | $status | ${requests:-–} | ${assertions:-–} | ${failed:-0} |" >> "$GITHUB_STEP_SUMMARY"
+
+          # Collect failing assertions so the summary says what broke, not just that
+          # something did. Written to a file rather than accumulated in a shell string,
+          # so nothing here can sit at column 0 and terminate this YAML block scalar.
+          if [[ "$status" == *failed* ]]; then
+            {
+              printf '\n<details><summary>Failures — %s</summary>\n\n' "$name"
+              printf '```\n'
+              grep -aE '^[[:space:]]*[0-9]+\.[[:space:]]+.*(AssertionError|expected)' "$log" | head -60 || true
+              printf '```\n</details>\n'
+            } >> postman-results/details.md
+          fi
         done < <(printf '%s' "$COLLECTIONS" | tr ',' '\n')
+
+        if [[ -s postman-results/details.md ]]; then
+          cat postman-results/details.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        {
+          echo
+          if [[ "$overall" == "0" ]]; then
+            echo "All collections passed."
+          else
+            echo "One or more collections failed — full output is in the **postman-results** artifact."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
         exit $overall
+
+    - name: Upload Postman results
+      if: always() && steps.pmauth.outputs.available == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: postman-results
+        path: postman-results/
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -31,12 +31,22 @@ on:
         required: false
         default: false
       fleetbase-ref:
-        description: Ref of fleetbase/fleetbase to boot (must match the ref that ships
-          this workflow + composite action + scripts).
+        description: >-
+          Ref of fleetbase/fleetbase to boot (ships the compose files, installer and
+          composite action). Tracks main by default so contract runs always exercise
+          the current platform — there is no per-release version to remember to bump.
+          Pin to a tag only when reproducing a specific failure.
         type: string
         required: false
-        # TODO: change to `main` once dev-v0.7.53 is merged.
-        default: dev-v0.7.53
+        default: main
+      api-image:
+        description: >-
+          API image to test against. Defaults to :latest, which is what each release
+          publishes, so this tracks the newest platform automatically. Pin to e.g.
+          fleetbase/fleetbase-api:v0.7.53 to reproduce an older result.
+        type: string
+        required: false
+        default: fleetbase/fleetbase-api:latest
       postman-ref:
         description: Ref of fleetbase/postman to run.
         type: string
@@ -94,7 +104,24 @@ jobs:
 
       - name: Pull published API image
         if: ${{ !inputs.build-from-source }}
-        run: docker pull fleetbase/fleetbase-api:latest
+        run: |
+          docker pull "${{ inputs.api-image }}"
+          # :latest is a moving target, so record the digest and build date the run
+          # actually used — otherwise a red run months from now is unreproducible.
+          # Raw newlines collapse in markdown, so fence it. `join` tolerates an image
+          # with no digest instead of erroring the way `index` would. The format string
+          # stays on one line — a wrapped one would end this YAML block scalar.
+          {
+            echo "### API image under test"
+            echo '```'
+            docker image inspect "${{ inputs.api-image }}" --format 'requested: ${{ inputs.api-image }}{{"\n"}}tags:      {{join .RepoTags ", "}}{{"\n"}}digest:    {{join .RepoDigests ", "}}{{"\n"}}created:   {{.Created}}'
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          # Retag so the compose file's fleetbase/fleetbase-api:latest reference resolves
+          # to the requested image even when a specific tag was asked for.
+          if [[ "${{ inputs.api-image }}" != "fleetbase/fleetbase-api:latest" ]]; then
+            docker tag "${{ inputs.api-image }}" fleetbase/fleetbase-api:latest
+          fi
 
       - name: Ensure clean database volume
         run: |

--- a/builds/linux/spc/libgeos-unix.php
+++ b/builds/linux/spc/libgeos-unix.php
@@ -24,7 +24,7 @@ trait libgeos
                 'LDFLAGS'  => $this->getLibExtraLdFlags(),
                 'LIBS'     => $this->getLibExtraLibs(),
             ])
-            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF ..")
+            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF -DBUILD_GEOSOP=OFF -DBUILD_TESTING=OFF -DGEOS_ENABLE_TESTS=OFF ..")
             ->execWithEnv("make -j{$this->builder->concurrency}")
             ->execWithEnv('make install');
 

--- a/builds/osx/spc/libgeos-unix.php
+++ b/builds/osx/spc/libgeos-unix.php
@@ -24,7 +24,7 @@ trait libgeos
                 'LDFLAGS'  => $this->getLibExtraLdFlags(),
                 'LIBS'     => $this->getLibExtraLibs(),
             ])
-            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF ..")
+            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF -DBUILD_GEOSOP=OFF -DBUILD_TESTING=OFF -DGEOS_ENABLE_TESTS=OFF ..")
             ->execWithEnv("make -j{$this->builder->concurrency}")
             ->execWithEnv('make install');
 


### PR DESCRIPTION
Answers two questions about the contract workflow: does the image have to be pinned, and why can't you see the Postman run?

## 1. It no longer has to be pinned

`fleetbase-ref` defaulted to `dev-v0.7.53` — a value someone has to remember to bump on every release, and which silently tests an old platform when they forget.

- `fleetbase-ref` now defaults to **`main`**.
- New **`api-image`** input defaults to **`fleetbase/fleetbase-api:latest`**, which is what each release publishes.

Callers therefore need no version at all:

```yaml
jobs:
  contract:
    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
    with:
      collections: "Fleetbase Storefront API"
      build-from-source: false
    secrets: inherit
```

Pinning still works for reproducing a specific failure (`api-image: fleetbase/fleetbase-api:v0.7.53`); a non-latest image is retagged so the compose file's `fleetbase/fleetbase-api:latest` reference resolves.

The tradeoff of tracking a moving tag is that a red run is hard to reproduce later, so the pull step now records the resolved tags, digest and build date into the step summary.

## 2. The run is now visible

Previously every collection ran inside `::group::` and reported only `✔ name passed` — collapsed by default, with no assertion counts and no endpoints.

- Output is **printed uncollapsed** and tee'd to `postman-results/`.
- The step summary gets a per-collection table:

  | Collection | Result | Requests | Assertions | Failed |
  | --- | --- | ---: | ---: | ---: |
  | Fleetbase API | ✅ passed | 42/0 | 180/0 | 0 |

- Failing assertions are expanded into a `<details>` block under the table.
- Full logs upload as the **`postman-results`** artifact (14 day retention).

## Bug fixed along the way

A missing collection directory was `::warning::` and did not fail the job — a typo in `collections` produced a green run that tested nothing. It is now `::error::` and fails.

## Verification

Both files validate as YAML, and the `run:` scripts were extracted and checked with `bash -n`. The summary-table parsing was dry-run against a sample Postman reporter log — that caught a real bug, since the reporter's table is drawn with box-drawing characters rather than ASCII pipes, so the original `requests` regex matched nothing. The `docker image inspect --format` string was run against a local image, confirming `join` tolerates an image with no digest where `index` would have errored.

Not verified end-to-end against a live run — that needs `POSTMAN_API_KEY`, which is why this PR is worth watching on its first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)