### PR TITLE
ci(api-contract): defer deletes at run time and mint a platform token

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -60,6 +60,7 @@ runs:
         CODE="$(base64 scripts/ci/mint-api-key.php | tr -d '\n')"
         OUT="$(docker compose exec -T application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
         KEY="$(printf '%s\n' "$OUT" | grep -oE 'flb_(live|test)_[A-Za-z0-9_-]+' | tail -1 || true)"
+        PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -67,6 +68,15 @@ runs:
         fi
         echo "::add-mask::$KEY"
         echo "api_key=$KEY" >> "$GITHUB_OUTPUT"
+        # A few endpoints (organizations listing, driver onboarding) sit behind the
+        # platform API token rather than an org credential and answer 401 to an
+        # flb_live_ key. Absent is not fatal — only those requests will 401.
+        if [[ -n "$PLATFORM_TOKEN" ]]; then
+          echo "::add-mask::$PLATFORM_TOKEN"
+          echo "platform_token=$PLATFORM_TOKEN" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::No platform token minted; platform-scoped requests will 401."
+        fi
         echo "Verifying key against ${{ inputs.base-url }}/${{ inputs.namespace }}/organizations/current ..."
         HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${KEY}" \
           "${{ inputs.base-url }}/${{ inputs.namespace }}/organizations/current" || true)"
@@ -102,6 +112,7 @@ runs:
       shell: bash
       env:
         API_KEY: ${{ steps.key.outputs.api_key }}
+        PLATFORM_TOKEN: ${{ steps.key.outputs.platform_token }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
         NAMESPACE: ${{ inputs.namespace }}
@@ -130,6 +141,7 @@ runs:
           '  --env-var "base_url=${BASE_URL}" \' \
           '  --env-var "namespace=${NAMESPACE}" \' \
           '  --env-var "api_key=${API_KEY}" \' \
+          '  --env-var "platform_token=${PLATFORM_TOKEN}" \' \
           '  "${@:2}"' > "$RUNNER"
         chmod +x "$RUNNER"
 
@@ -165,7 +177,22 @@ runs:
           # for them outright:
           #   Error: Reporter "json" is not supported for multi-protocol collections.
           # So the summary below is parsed from the cli reporter's ASCII table.
+          # Run every request explicitly, in the collection's own order but with each
+          # DELETE moved to the end. The collection is published as API reference
+          # documentation, so its structure and ordering cannot be changed to suit the
+          # test run — but a delete that fires mid-run destroys a record the remaining
+          # requests still need, which is what produced most of the 404s. The CLI
+          # honours the order of repeated -i flags, so deferring them costs nothing and
+          # keeps DELETE coverage intact.
           args=("$dir" -r cli)
+          if [[ -f scripts/ci/order-collection-requests.py ]]; then
+            while IFS= read -r req; do
+              [[ -n "$req" ]] && args+=(-i "$req")
+            done < <(python3 scripts/ci/order-collection-requests.py "$dir")
+            echo "  running $(( (${#args[@]} - 2) / 2 )) requests, deletes deferred to the end"
+          else
+            echo "::warning::order-collection-requests.py not found; running in natural order (deletes may strand later requests)."
+          fi
 
           # The CLI does NOT resolve the collection variables declared in
           # .resources/definition.yaml — verified: with no --env-var at all, even

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -40,6 +40,15 @@ try {
     );
 
     echo PHP_EOL . 'MINTED_API_KEY=' . $credential->fresh()->key . PHP_EOL;
+
+    // A handful of endpoints (organizations listing, driver onboarding) sit behind
+    // AuthenticatePlatformApiToken rather than an org API credential, and answer 401
+    // to an flb_live_ key. Only the hash is persisted, so the plaintext cannot be read
+    // back — rotating is the only way to learn a usable token. Safe here because this
+    // script only ever runs against a throwaway CI stack; do not run it against an
+    // install whose platform token is already in use.
+    $platformToken = \Fleetbase\Support\PlatformApi::rotateToken();
+    echo 'MINTED_PLATFORM_TOKEN=' . $platformToken . PHP_EOL;
 } catch (\Throwable $e) {
     echo PHP_EOL . 'MINT_ERROR: ' . get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
     echo $e->getFile() . ':' . $e->getLine() . PHP_EOL;

--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Emit `-i <Folder/Request>` args for a Postman git-native collection directory,
+in the collection's own order, with every DELETE deferred to the end.
+
+The collection doubles as published API reference, so its on-disk structure and
+ordering must not change. Deferring deletes at run time keeps DELETE coverage
+without letting a delete destroy a record the rest of the run still needs.
+"""
+import os, re, sys
+
+root = sys.argv[1]
+def field(path, key, default=None):
+    try:
+        m = re.search(rf'^{key}:\s*(\S+)', open(path, encoding='utf-8').read(), re.M)
+        return m.group(1) if m else default
+    except OSError:
+        return default
+
+items = []
+for folder in os.listdir(root):
+    d = os.path.join(root, folder)
+    if not os.path.isdir(d) or folder.startswith('.'):
+        continue
+    forder = int(field(os.path.join(d, '.resources', 'definition.yaml'), 'order', 10**9))
+    for fn in os.listdir(d):
+        if not fn.endswith('.request.yaml'):
+            continue
+        p = os.path.join(d, fn)
+        name = fn[:-len('.request.yaml')]
+        method = (field(p, 'method', '?') or '?').upper()
+        rorder = int(field(p, 'order', 10**9))
+        items.append((method == 'DELETE', forder, folder, rorder, name))
+
+for _is_delete, _fo, folder, _ro, name in sorted(items):
+    print(f'{folder}/{name}')


### PR DESCRIPTION
Pairs with [fleetbase/postman#11](https://github.com/fleetbase/postman/pull/11). Together they take the Fleetbase API collection from **85 of 180 requests returning 2xx to 129 of 180**, with no change to the collection's structure.

## Deletes are deferred at run time, not restructured

The collections are published as API reference documentation, so their organisation can't be reshaped to suit a test run. But a `DELETE` firing mid-run destroys a record the remaining requests still need — `Delete a Driver` removes `{{driver_id}}` twenty requests before `Issues/Create an Issue` uses it, which is exactly the 404 that started this.

The Postman CLI honours the order of repeated `-i` flags. I verified this by asking for `Retrieve a Place` before `Create a Place` and watching Retrieve run first. So `scripts/ci/order-collection-requests.py` lists every request in the collection's own order — folder `order:` from `.resources/definition.yaml`, then request `order:` — with each DELETE moved to the end.

DELETE coverage is unchanged, nothing is stranded, and **no file in the collection moves**.

An earlier attempt added fifteen `Create a Disposable X` requests instead. That worked, but those would have appeared in the published docs, so it was reverted in favour of this.

**One caveat worth knowing:** a single `-i` that matches nothing aborts the entire run with zero requests executed and a non-obvious error. The generator derives names from the collection itself rather than a static list, so it cannot drift out of sync.

## The seed script now mints a platform token

`List Organizations` sits behind `AuthenticatePlatformApiToken`, not an organization API credential, so it answered 401 to the `flb_live_` key no matter what. `scripts/ci/mint-api-key.php` now also calls `PlatformApi::rotateToken()` and prints the token, which the action captures, masks and passes through as `{{platform_token}}`.

Only the hash is persisted, so rotating is the only way to learn a usable token. That is safe against a throwaway CI stack — the script is already CI-only — and the step emits a warning rather than failing when no token is minted.

## Verification

Every number measured against a live stack, not inferred:

| state | 2xx |
| --- | ---: |
| baseline | 85/180 |
| + deferred deletes | 116/180 |
| + payload/entity body fixes | 127/180 |
| + platform token | **129/180** |

Both YAML files validate, and the `run:` scripts pass `bash -n`.

## What still fails

51 remain, and most are not collection-shaped problems: the Customers folder needs a verification code that cannot be obtained from a collection (15), `POST /v1/parts` and `POST /v1/fuel-transactions` return **500** and take 12 dependent requests with them, `GET /v1/onboard` returns a 500 with an HTML stack trace, and the Orchestrator needs the vroom service. Those are being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)