### PR TITLE
ci(api-contract): test the branch's own API code, not the published package

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -8,7 +8,12 @@ name: API Contract (Postman)
 #   jobs:
 #     contract:
 #       uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
-#       with: { collections: "Fleetbase Storefront API", build-from-source: false }
+#       with:
+#         collections: "Fleetbase Storefront API"
+#         build-from-source: false
+#         # Without overlay-package the run tests the version of this module baked into
+#         # the published image, NOT the branch under review.
+#         overlay-package: fleetbase/storefront-api
 #       secrets: inherit
 #
 # Requires org-level secrets POSTMAN_API_KEY and _GITHUB_AUTH_TOKEN (inherited).
@@ -47,6 +52,23 @@ on:
         type: string
         required: false
         default: fleetbase/fleetbase-api:latest
+      overlay-package:
+        description: >-
+          Composer package inside the API image to replace with the CALLING repository's
+          checked-out source, e.g. fleetbase/fleetops-api. Without this a module's
+          contract run exercises whatever version of that module is baked into the
+          published image, not the branch under review — so a PR's own API changes are
+          never actually tested. Leave empty to test the image as published.
+        type: string
+        required: false
+        default: ''
+      overlay-path:
+        description: >-
+          Directory within the calling repository that is the package root (the folder
+          containing its composer.json). Defaults to the repository root.
+        type: string
+        required: false
+        default: .
       postman-ref:
         description: Ref of fleetbase/postman to run.
         type: string
@@ -143,6 +165,78 @@ jobs:
             sleep 5
           done
           echo "::error::API did not become healthy"; exit 1
+
+      # In a reusable workflow github.repository/github.sha refer to the CALLER, so this
+      # checks out the module branch under review rather than fleetbase/fleetbase.
+      - name: Checkout calling repository for overlay
+        if: ${{ inputs.overlay-package != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          token: ${{ secrets._GITHUB_AUTH_TOKEN }}
+          path: .overlay
+
+      - name: Overlay branch source over the published package
+        if: ${{ inputs.overlay-package != '' }}
+        run: |
+          set -uo pipefail
+          PKG="${{ inputs.overlay-package }}"
+          SRC=".overlay/${{ inputs.overlay-path }}"
+          DEST="/fleetbase/api/vendor/${PKG}"
+
+          if [[ ! -f "$SRC/composer.json" ]]; then
+            echo "::error::No composer.json at ${SRC}; set overlay-path to the package root."
+            exit 1
+          fi
+
+          WAS="$(docker compose exec -T application sh -c "cat ${DEST}/composer.json 2>/dev/null" \
+                  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version","unknown"))' 2>/dev/null || echo unknown)"
+
+          # Replace rather than merge, so files deleted on the branch actually disappear.
+          # The branch has no vendor/ of its own (never installed), so nothing to exclude.
+          docker compose exec -T application sh -c "rm -rf ${DEST} && mkdir -p ${DEST}"
+          tar -C "$SRC" -cf - . | docker compose exec -T application sh -c "tar -C ${DEST} -xf -"
+          docker compose exec -T application sh -c "chown -R www-data:www-data ${DEST}"
+
+          # The image is built with --optimize-autoloader, which freezes a classmap.
+          # Without dumping it, classes added on the branch are simply not found.
+          docker compose exec -T application su www-data -s /bin/sh -c \
+            "cd /fleetbase/api && composer dump-autoload --optimize --no-scripts" 2>&1 | tail -3
+
+          # A branch may ship new migrations, and stale caches would mask new routes/config.
+          docker compose exec -T application su www-data -s /bin/sh -c \
+            "cd /fleetbase/api && php artisan optimize:clear" 2>&1 | tail -5
+          docker compose exec -T application su www-data -s /bin/sh -c \
+            "cd /fleetbase/api && php artisan migrate --force" 2>&1 | tail -10
+
+          # New composer requirements on the branch are NOT installed by this overlay.
+          # Surface that rather than letting it fail later as a confusing class-not-found.
+          if ! diff -q <(python3 -c "import json;print(json.dumps(json.load(open('$SRC/composer.json')).get('require',{}),sort_keys=True))") \
+                       <(docker compose exec -T application sh -c "cat ${DEST}/composer.json" \
+                         | python3 -c "import json,sys;print(json.dumps(json.load(sys.stdin).get('require',{}),sort_keys=True))") >/dev/null 2>&1; then
+            echo "::warning::${PKG} changed its composer requires on this branch; the overlay does not install new dependencies."
+          fi
+
+          {
+            echo "### Package under test"
+            echo
+            echo "\`${PKG}\` replaced with **${{ github.repository }}@${{ github.sha }}**"
+            echo "(image shipped version \`${WAS}\`)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Re-check API health after overlay
+        if: ${{ inputs.overlay-package != '' }}
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS --max-time 5 http://localhost:8000/health | grep -q '"status"'; then
+              echo "API healthy after overlay"; exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::API did not recover after overlaying ${{ inputs.overlay-package }}"
+          docker compose logs --no-color --tail=100 application || true
+          exit 1
 
       - name: Run Postman contract
         uses: ./.github/actions/postman-contract


### PR DESCRIPTION
Stacked on #579.

## The problem

Your assumption was right. With `build-from-source: false` the workflow pulls `fleetbase/fleetbase-api:latest`, and every module is a **composer dependency baked into that image**:

```
api/composer.json:  "fleetbase/fleetops-api": "^0.6.59"
```

Confirmed inside a running container — it is a plain vendor directory, not a symlink:

```
vendor/fleetbase/fleetops-api        (installed.json: version 0.6.59)
```

So a fleetops PR booted 0.6.59 and ran the collections against it. **The PR's own API changes were never tested.** The check was green on code that was not under review — arguably worse than no check, because it looks like coverage.

## The fix

A new optional `overlay-package` input. When set, the workflow checks out the **calling** repository at the commit under review — in a reusable workflow `github.repository` and `github.sha` refer to the caller — and replaces that package inside the running container.

```yaml
jobs:
  contract:
    uses: fleetbase/fleetbase/.github/workflows/api-contract.yml@main
    with:
      collections: "Fleetbase API"
      build-from-source: false
      overlay-package: fleetbase/fleetops-api
    secrets: inherit
```

`overlay-path` is available if the package root is not the repository root; for fleetops it is the root (`composer.json` there declares `fleetbase/fleetops-api`, PSR-4 `Fleetbase\FleetOps\` → `server/src/`).

## Why each step is there

**`composer dump-autoload` is not optional.** The image is built with `--optimize-autoloader`, and the frozen classmap holds **579 FleetOps entries** with absolute file paths. A class added or moved on the branch would simply not resolve without it. Verified directly in the container.

**Migrations run** because a branch may ship new ones. **Caches are cleared** so stale config/route caches don't mask new routes.

**Health is re-checked afterwards**, so a broken overlay fails loudly rather than surfacing as confusing 500s inside the contract output.

**Replace, not merge** — files deleted on the branch actually disappear.

## Known limitation

The overlay does **not** install new composer requirements. If the branch changes its `require` block, that is reported as a `::warning::` rather than left to fail later as a baffling class-not-found. Handling it properly would mean a full `composer update` in the container, which is slow and needs registry auth; worth doing only if it turns out to bite.

## Verification

Established against a running stack:

- `fleetbase/fleetops-api` is a plain vendor directory at **0.6.59** — the mechanism of the bug
- the package root is the repository root, PSR-4 `Fleetbase\FleetOps\` → `server/src/`
- the classmap is frozen with 579 FleetOps entries — the reason `dump-autoload` is required
- composer 2.10.1 is available in the container

YAML validates and every `run:` step passes `bash -n`.

**The overlay is not yet exercised end to end.** I deliberately did not run it against the dev stack, since it would have replaced that machine's fleetops vendor directory. The first module PR to set `overlay-package` will prove it, and is the right place to watch.

## Follow-up

The four module workflows need `overlay-package` added to actually benefit — one line each:

| repo | value |
| --- | --- |
| fleetops | `fleetbase/fleetops-api` |
| storefront | `fleetbase/storefront-api` |
| ledger | `fleetbase/ledger-api` |
| core-api | `fleetbase/core-api` |

Happy to open those once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)