### PR TITLE
ci(api-contract): capture response bodies so contract failures are diagnosable

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -45,6 +45,15 @@ inputs:
       drift apart. Quoted because unquoted 000000 is YAML for the integer 0.
     required: false
     default: '000000'
+  verbose:
+    description: >-
+      Run the CLI with --verbose so request and response bodies are captured. Without
+      it a failing request records only a status code and a byte count, which is not
+      enough to tell a bad request body from a broken endpoint. Bodies are kept in the
+      uploaded artifact with Authorization headers scrubbed; the job log relies on
+      ::add-mask:: for the same secrets.
+    required: false
+    default: 'true'
   postman-ref:
     description: Ref of the fleetbase/postman repo to check out.
     required: false
@@ -270,6 +279,9 @@ runs:
           # RUN_LAST in order-collection-requests.py. The CLI honours the order of
           # repeated -i flags, so deferring costs nothing and keeps coverage intact.
           args=("$dir" -r cli)
+          if [[ "${{ inputs.verbose }}" == "true" ]]; then
+            args+=(--verbose)
+          fi
           if [[ -f scripts/ci/order-collection-requests.py ]]; then
             while IFS= read -r req; do
               [[ -n "$req" ]] && args+=(-i "$req")
@@ -327,6 +339,14 @@ runs:
           # Strip the colour codes and the PTY's carriage returns for the plain copy, so
           # the artifact is readable in an editor rather than full of escape sequences.
           sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g; s/\r$//' "$ansi" > "$log"
+
+          # --verbose echoes request headers, so the minted bearer token would otherwise
+          # be written verbatim into an uploaded artifact. ::add-mask:: covers the job
+          # log but does NOT apply to artifacts, so scrub both copies explicitly.
+          for f in "$ansi" "$log"; do
+            sed -i -E 's/(Authorization:[[:space:]]*Bearer[[:space:]]*)[A-Za-z0-9._-]+/\1<redacted>/gi; \
+                       s/(flb_(live|test|platform)_)[A-Za-z0-9_-]+/\1<redacted>/g' "$f"
+          done
 
           # Read executed/failed out of the reporter's summary table. Each row is
           # "| <label> | <executed> | <failed> |", so match the label plus two numbers


### PR DESCRIPTION
Investigating [the fleetops run](https://github.com/fleetbase/fleetops/actions/runs/31364523707) stalled on missing evidence, not on analysis.

**61 of its 70 `400`s share an identical 457-byte body** — plainly one systemic cause. But the run records only a status code and a byte count. There is no request body, no response body, nowhere. So distinguishing "the collection sends the wrong thing" from "the endpoint is broken" meant reproducing hypotheses by hand against a live stack, one at a time. I ruled out fresh-company permissions and referential-integrity-blocking-deletes that way; both were dead ends that cost a round trip each.

## Change

Run the CLI with `--verbose`, so request and response bodies land in the job log and the `postman-results` artifact. Behind a `verbose` input (default `true`) in case the extra output becomes a nuisance.

## Secrets

`--verbose` echoes request headers, which carry the minted `flb_live_` bearer token. `::add-mask::` covers the **job log** but does **not** apply to uploaded artifacts — an artifact would have contained the token verbatim.

Both archived copies are therefore scrubbed explicitly:

```
Authorization: Bearer <token>   ->  Authorization: Bearer <redacted>
flb_live_… / flb_test_… / flb_platform_…  ->  flb_live_<redacted>
```

Verified against a fixture containing all three token shapes plus a mixed-case `authorization: bearer` header — no secret material survives.

## What this unblocks

The next contract run should say outright what the 457-byte body is, instead of leaving it to be inferred from response sizes. Same for the four `500`s and the remaining `422`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)