### PR TITLE
ci(api-contract): stop the contract run throttling itself

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -153,6 +153,25 @@ jobs:
       - name: Run non-interactive installer
         run: |
           [ -f api/.env ] || cp api/.env.example api/.env 2>/dev/null || touch api/.env
+
+          # The public API throttles 120 requests/minute, and ThrottleRequests sits
+          # FIRST in the fleetbase.api middleware group — before authentication — so
+          # $request->user() is null and the bucket is keyed per IP rather than per API
+          # key. A contract run is ~180 requests in about a minute from one runner, so
+          # it throttles itself: measured, 61 requests came back
+          # {"errors":["Too many requests."]}, every one of them a false failure.
+          #
+          # Must be the literal string false. ThrottleRequests checks
+          # `config('api.throttle.enabled', true) === false`, and env() casts "false" to
+          # a boolean but leaves "0" as the string "0", which is !== false and would
+          # silently leave throttling on.
+          if grep -q '^THROTTLE_ENABLED=' api/.env; then
+            sed -i 's/^THROTTLE_ENABLED=.*/THROTTLE_ENABLED=false/' api/.env
+          else
+            echo 'THROTTLE_ENABLED=false' >> api/.env
+          fi
+          echo "Throttling disabled for the contract run: $(grep '^THROTTLE_ENABLED=' api/.env)"
+
           bash scripts/docker-install.sh --non-interactive
 
       - name: Wait for API health


### PR DESCRIPTION
**61 of the fleetops run's 83 failures were one cause**, visible the moment #583 started capturing bodies:

```json
{"errors":["Too many requests."]}
```

The contract run was rate-limiting itself.

## Mechanism

`ThrottleRequests` sits **first** in the `fleetbase.api` middleware group (`CoreServiceProvider.php:64-70`) — before `AuthenticateOnceWithBasicAuth`. So `$request->user()` is still null when Laravel computes the throttle key, and it falls through to:

```php
return $this->formatIdentifier($route->getDomain().'|'.$request->ip());
```

**Per IP, not per API key.** The limit is 120/minute (`api.throttle.max_attempts`), shared across `fleetbase.api`, `fleetbase.platform-api` and the public auth routes.

A contract run is ~180 requests inside a minute from a single runner, so it exhausts its own budget. The first throttled request lands at roughly position 120 — exactly where the failures start.

It also explains the pattern that had me chasing referential integrity: **every DELETE failed** because deferring deletes to the end of the run puts them past the point where the budget is gone.

## Fix

`THROTTLE_ENABLED=false` in `api/.env` before the installer runs.

It must be the literal `false`. `ThrottleRequests` checks `config('api.throttle.enabled', true) === false`; `env()` casts `"false"` to a boolean but leaves `"0"` as the string `"0"`, which is `!== false` and would silently leave throttling on. Both the replace and append paths were exercised.

## A real bug this exposed

The throttle answers **HTTP 400, not 429**. `Handler.php:208` passes `429`, but that argument was added *after* `v1.6.55`, and the released core-api the image installs still calls `response()->error('Too many requests.')` with no status — so the macro's `int $statusCode = 400` default wins.

An API consumer therefore cannot detect rate limiting by status code, and gets a 400 that looks like a malformed request. Already fixed on the core-api branch; it needs a release to reach the published image. Worth its own issue.

## What this does not fix

The other 22 failures are genuine and now legible, e.g.:

- `{"error":"Customer contact type cannot be changed."}`
- `{"error":"Email \"null\" does not comply with addr-spec of RFC 2822."}`
- `{"error":"Place resource is not a valid destination."}`
- one HTML 500: `Call to a member function input() on null`

Those are separate fixes in the collection and in fleetops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)