### PR TITLE
fix(api-contract): use declared request names, and fail a zero-request run

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -369,6 +369,14 @@ runs:
           # A collection with no assertions cannot fail on a bad response — it only
           # catches transport errors, so a 500 from every endpoint still reads as green.
           # Say so rather than letting the row imply the API was verified.
+          # A collection that executed nothing is a failure, not a pass. The CLI
+          # aborts the whole run when one -i name does not match a collection item
+          # and reports 0 requests executed, which otherwise reads as a clean run.
+          if [[ "${r_exec:-0}" == "0" ]]; then
+            echo "::error::'$name' executed 0 requests. Usually a -i name that matches no collection item; look for 'items were not found' in the log."
+            overall=1
+          fi
+
           if [[ "${a_exec:-0}" == "0" ]]; then
             echo "::warning::'$name' ran ${r_exec:-0} requests but executed no assertions; it cannot detect a bad response."
             printf '\n> ⚠️ **%s** executed no assertions — it only catches transport errors.\n' \

--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -67,6 +67,21 @@ def field(path, key, default=None):
 # Pinned order for this collection, as {path: index}. Unknown collection => {}.
 run_last = {p: i for i, p in enumerate(RUN_LAST.get(os.path.basename(root.rstrip('/')), []))}
 
+def line_value(path, key):
+    """Read a scalar whose value may contain spaces, e.g. `name: A long title`.
+
+    field() stops at the first token, which silently truncated request names to
+    their first word and made every -i miss.
+    """
+    try:
+        m = re.search(rf'^{key}:[ \t]*(.+?)[ \t]*$', open(path, encoding='utf-8').read(), re.M)
+    except OSError:
+        return None
+    if not m:
+        return None
+    return m.group(1).strip().strip('"').strip("'")
+
+
 items = []
 seen = set()
 for folder in os.listdir(root):
@@ -78,7 +93,12 @@ for folder in os.listdir(root):
         if not fn.endswith('.request.yaml'):
             continue
         p = os.path.join(d, fn)
-        name = fn[:-len('.request.yaml')]
+        # Prefer the request's declared name over the filename. They usually match,
+        # but the on-disk name is truncated at 60 characters, so a longer request
+        # (e.g. Storefront's "Setups a verification request to create a new storefront
+        # customer. ?") ends up with a filename the collection does not know. `-i` then
+        # fails to match it and the CLI aborts the ENTIRE run with 0 requests executed.
+        name = (line_value(p, 'name') or fn[:-len('.request.yaml')])
         method = (field(p, 'method', '?') or '?').upper()
         rorder = int(field(p, 'order', 10**9))
         path = f'{folder}/{name}'


### PR DESCRIPTION
The storefront contract run executed **0 of 60 requests**. The job reported a failed collection, with the actual cause buried in the log:

```
Error: The following items were not found in the collection:
Customer/Setups a verification request to create a new storefront custome
```

## Cause

`order-collection-requests.py` names each `-i` target after its **filename**. On-disk names are truncated at 60 characters:

```
file: Setups a verification request to create a new storefront custome
name: Setups a verification request to create a new storefront customer. ?
```

The CLI **aborts the entire run** when a single `-i` target matches no item. So one over-long title took out all 60 storefront requests — my bug, introduced with the deferred-delete ordering.

## Fix

Read the request's declared `name:`, falling back to the filename.

That needed a second reader: the existing `field()` helper matches `\S+` and stops at the first token, which would have turned the same request into `Customer/Setups`. Added `line_value()` for scalars containing spaces.

Verified across all five collections — **273 emitted names, 0 unmatched**.

## Guard

A collection that executes 0 requests now fails with an explicit error naming the likely cause. Previously it surfaced only as a failed collection, and would have read as a clean run had it been the only collection. Same class as the earlier "no collections ran" guard, which this slipped past because that one counts collections, not requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)