### PR TITLE
ci(api-contract): seed a storefront key so that collection can authenticate

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -110,6 +110,7 @@ runs:
         KEY="$(printf '%s\n' "$OUT" | grep -oE 'flb_(live|test)_[A-Za-z0-9_-]+' | tail -1 || true)"
         PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
         ORGANIZATION_ID="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_COMPANY_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        STOREFRONT_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_STOREFRONT_KEY=store_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -138,6 +139,14 @@ runs:
         # The organizations listing sits behind the platform API token rather than an
         # org credential and answers 401 to an flb_live_ key. Absent is not fatal —
         # only those requests will 401.
+        # The Storefront API rejects any bearer token that is not a store/network key,
+        # so its collection cannot use the organization credential at all.
+        if [[ -n "$STOREFRONT_KEY" ]]; then
+          echo "::add-mask::$STOREFRONT_KEY"
+          echo "storefront_key=$STOREFRONT_KEY" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::No storefront key minted; the Storefront collection will 401."
+        fi
         if [[ -n "$PLATFORM_TOKEN" ]]; then
           echo "::add-mask::$PLATFORM_TOKEN"
           echo "platform_token=$PLATFORM_TOKEN" >> "$GITHUB_OUTPUT"
@@ -180,6 +189,7 @@ runs:
       env:
         API_KEY: ${{ steps.key.outputs.api_key }}
         PLATFORM_TOKEN: ${{ steps.key.outputs.platform_token }}
+        STOREFRONT_KEY: ${{ steps.key.outputs.storefront_key }}
         ORGANIZATION_ID: ${{ steps.key.outputs.organization_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
@@ -226,6 +236,7 @@ runs:
           '  --env-var "namespace=${NAMESPACE}" \' \
           '  --env-var "api_key=${API_KEY}" \' \
           '  --env-var "platform_token=${PLATFORM_TOKEN}" \' \
+          '  --env-var "storefront_key=${STOREFRONT_KEY}" \' \
           '  --env-var "organization_id=${ORGANIZATION_ID}" \' \
           '  --env-var "customer_identity=${CUSTOMER_IDENTITY}" \' \
           '  --env-var "customer_email=${CUSTOMER_IDENTITY}" \' \

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -142,6 +142,36 @@ try {
     $seedVerificationCode('fleetops_customer_login');
     $seedVerificationCode('fleetops_customer_password_reset', ['identity' => $customerIdentity]);
 
+    // The Storefront API authenticates with a store/network key, not an organization
+    // API credential: SetStorefrontSession rejects any bearer token that does not start
+    // with "store" or "network", so the flb_live_ key above can never authenticate a
+    // Storefront request. Seed a store so the Storefront collection has a usable key.
+    // Guarded because the extension is not installed in every stack.
+    if (class_exists(\Fleetbase\Storefront\Models\Store::class)) {
+        $store = \Fleetbase\Storefront\Models\Store::where([
+            'company_uuid' => $company->uuid,
+            'name'         => 'CI Contract Store',
+        ])->first();
+
+        if (!$store) {
+            // Store::boot() sets `key` to 'store_' . md5(...) on creating, so the key
+            // exists only after the insert — it cannot be supplied.
+            $store = \Fleetbase\Storefront\Models\Store::create([
+                'company_uuid'    => $company->uuid,
+                'created_by_uuid' => $user->uuid,
+                'name'            => 'CI Contract Store',
+                'description'     => 'Seeded by the API contract run.',
+                'currency'        => 'USD',
+                'online'          => 1,
+            ]);
+        }
+
+        echo 'MINTED_STOREFRONT_KEY=' . $store->fresh()->key . PHP_EOL;
+        echo 'MINTED_STOREFRONT_ID=' . $store->public_id . PHP_EOL;
+    } else {
+        echo 'MINTED_STOREFRONT_KEY=' . PHP_EOL;
+    }
+
     echo 'SEEDED_CUSTOMER_IDENTITY=' . $customerIdentity . PHP_EOL;
     echo 'SEEDED_CUSTOMER_PHONE=' . $customerPhone . PHP_EOL;
     echo 'SEEDED_VERIFICATION_CODE=' . $customerCode . PHP_EOL;


### PR DESCRIPTION
The Storefront collection cannot authenticate with the organization API credential, and no amount of collection fixing changes that.

`SetStorefrontSession` rejects any bearer token that isn't a store/network key:

```php
if (!Str::startsWith($key, ['network', 'store'])) {
    return response()->error('Oops! The Storefront key provided was not valid', 401);
}
```

So the `flb_live_` key can never authenticate a Storefront request — and the seed script never created a storefront at all. That is why all 60 of its requests fail regardless of the empty-`Authorization` fix.

## Change

Seeds a `Store` for the CI company and exposes its key as `{{storefront_key}}`.

`Store::boot()` sets `key` to `'store_' . md5(...)` on **creating**, so the key only exists after the insert and cannot be supplied — the store is created, then re-read.

Guarded with `class_exists` because the extension isn't installed in every stack. Absent, the run emits a warning rather than failing, and only the Storefront collection is affected.

Also prints the store's `public_id`, which storefront requests use to address a store by id.

## Still needed for Storefront to pass

This is the credential half. The other half is the collection: its bearer must become `{{storefront_key}}` instead of `{{api_key}}`, and the 12 customer-gated endpoints need a `Customer-Token` header chained from a login.

`CustomerController@login` returns the Sanctum token at the top level of the response (`Customer.php:43`, `token` emitted via `$this->when(...)`), so a login request can capture it into `{{customer_token}}`. The already-seeded CI customer has a known password, so the password login is deterministic — unlike signup, which needs a genuine emailed code and has no bypass.

That part lands in fleetbase/postman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)