### PR TITLE
fix(api-contract): the secret scrub never ran

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -354,9 +354,15 @@ runs:
           # --verbose echoes request headers, so the minted bearer token would otherwise
           # be written verbatim into an uploaded artifact. ::add-mask:: covers the job
           # log but does NOT apply to artifacts, so scrub both copies explicitly.
+          # Two -e expressions rather than one wrapped with a backslash: inside single
+          # quotes a trailing \ is NOT a line continuation, so sed received a literal
+          # backslash-newline and died with "unterminated address regex" — meaning the
+          # scrub silently did not run and the artifact kept the bearer token.
           for f in "$ansi" "$log"; do
-            sed -i -E 's/(Authorization:[[:space:]]*Bearer[[:space:]]*)[A-Za-z0-9._-]+/\1<redacted>/gi; \
-                       s/(flb_(live|test|platform)_)[A-Za-z0-9_-]+/\1<redacted>/g' "$f"
+            sed -i -E \
+              -e 's/(Authorization:[[:space:]]*Bearer[[:space:]]*)[A-Za-z0-9._-]+/\1<redacted>/gi' \
+              -e 's/(flb_(live|test|platform)_)[A-Za-z0-9_-]+/\1<redacted>/g' \
+              "$f"
           done
 
           # Read executed/failed out of the reporter's summary table. Each row is


### PR DESCRIPTION
Spotted in the [fleetops run](https://github.com/fleetbase/fleetops/actions/runs/31381740774):

```
sed: -e expression #1, char 156: unterminated address regex
```

The scrub was one sed expression wrapped with a trailing backslash. **Inside single quotes a trailing ` \ ` is not a line continuation** — sed received a literal backslash and newline and errored, so redaction silently did not happen.

No secret has actually leaked, but only by luck: every verbose run since has executed 0 requests, so no request headers were written to the log. The next *successful* run would have written the minted `flb_live_` bearer token into an uploaded artifact verbatim — and `::add-mask::` does not apply to artifacts.

Split into two `-e` expressions. Verified both directions: the old form errors, the new form redacts an `Authorization: Bearer` value and all three `flb_` token shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)