### PR TITLE
ci(api-contract): give the contract stack a geocoding key

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -151,6 +151,8 @@ jobs:
           mkdir -p docker/database/mysql
 
       - name: Run non-interactive installer
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: |
           [ -f api/.env ] || cp api/.env.example api/.env 2>/dev/null || touch api/.env
 
@@ -171,6 +173,25 @@ jobs:
             echo 'THROTTLE_ENABLED=false' >> api/.env
           fi
           echo "Throttling disabled for the contract run: $(grep '^THROTTLE_ENABLED=' api/.env)"
+
+          # Place::createFromMixed resolves a place string by matching an existing
+          # street1/name first, then falls through to createFromGeocodingLookup. The
+          # order shapes that send a real street address ("Singapore 018971") have no
+          # seeded match, so without a key they cannot resolve and those requests fail
+          # for a reason that has nothing to do with the API under test.
+          #
+          # Optional on purpose: absent, the run still covers createFromMixed through
+          # the coordinate and GeoJSON shapes, which need no external service.
+          if [[ -n "${GOOGLE_MAPS_API_KEY:-}" ]]; then
+            if grep -q '^GOOGLE_MAPS_API_KEY=' api/.env; then
+              sed -i "s|^GOOGLE_MAPS_API_KEY=.*|GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}|" api/.env
+            else
+              echo "GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}" >> api/.env
+            fi
+            echo "Geocoding enabled: address-string place resolution will use Google Maps."
+          else
+            echo "::notice::GOOGLE_MAPS_API_KEY not set; order shapes that send a street address cannot geocode. Coordinate and GeoJSON shapes are unaffected."
+          fi
 
           bash scripts/docker-install.sh --non-interactive
 


### PR DESCRIPTION
Follow-up to [postman#21](https://github.com/fleetbase/postman/pull/21), which promoted the Create Order examples to runnable requests.

`Place::createFromMixed` resolves a place string by matching an existing `street1`/`name` first, then falls through to `createFromGeocodingLookup`. Two of the promoted shapes send a real street address (`"Singapore 018971"`) with no seeded match, so without a key they cannot resolve — and would fail for a reason that has nothing to do with the API under test.

Writes `GOOGLE_MAPS_API_KEY` into `api/.env` from the inherited org secret before the installer runs, so the geocoder chain in `packages/fleetops/server/config/geocoder.php` picks it up via `services.google_maps.api_key`.

## Optional on purpose

Absent, the run emits a `::notice::` and continues. The **Coordinates** and **GeoJSON** order shapes exercise `createFromMixed` with no external service, so place-resolution coverage survives either way.

That is deliberate: a contract run should not hard-depend on a third-party service being reachable, or an outage at Google becomes a red build on every module.

## Verification

All three paths exercised — key present (appends), key present with the variable already in `api/.env` (replaces), and key absent (writes nothing, emits the notice). YAML validates and the step passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)