### PR TITLE
ci(api-contract): seed driver fixtures for the Drivers auth flows

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -45,6 +45,24 @@ inputs:
       drift apart. Quoted because unquoted 000000 is YAML for the integer 0.
     required: false
     default: '000000'
+  driver-identity:
+    description: >-
+      Email of the seeded CI driver. Login Driver resolves a User by phone OR email that
+      has a related Driver record, so this must match a seeded driver, not the credential
+      owner.
+    required: false
+    default: ci-driver@fleetbase.local
+  driver-password:
+    description: Password for the seeded CI driver. Minimum 8 characters.
+    required: false
+    default: CiDriverPassw0rd!
+  driver-phone:
+    description: >-
+      Phone for the seeded CI driver, E.164. Request Driver Login SMS resolves a user by
+      this number and 400s with "No driver with this phone # found." if it matches none.
+      Must differ from customer-phone — the lookup is by number alone.
+    required: false
+    default: '+15555550124'
   verbose:
     description: >-
       Run the CLI with --verbose so request and response bodies are captured. Without
@@ -90,6 +108,9 @@ runs:
         CUSTOMER_PASSWORD: ${{ inputs.customer-password }}
         CUSTOMER_PHONE: ${{ inputs.customer-phone }}
         VERIFICATION_CODE: ${{ inputs.customer-verification-code }}
+        DRIVER_IDENTITY: ${{ inputs.driver-identity }}
+        DRIVER_PASSWORD: ${{ inputs.driver-password }}
+        DRIVER_PHONE: ${{ inputs.driver-phone }}
       run: |
         set -uo pipefail
         # Run the mint snippet via `tinker --execute="eval(base64_decode(...))"`.
@@ -106,6 +127,9 @@ runs:
           -e "CI_CUSTOMER_PHONE=${CUSTOMER_PHONE}" \
           -e "CI_CUSTOMER_PASSWORD=${CUSTOMER_PASSWORD}" \
           -e "CI_CUSTOMER_VERIFICATION_CODE=${VERIFICATION_CODE}" \
+          -e "CI_DRIVER_IDENTITY=${DRIVER_IDENTITY}" \
+          -e "CI_DRIVER_PHONE=${DRIVER_PHONE}" \
+          -e "CI_DRIVER_PASSWORD=${DRIVER_PASSWORD}" \
           application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
         KEY="$(printf '%s\n' "$OUT" | grep -oE 'flb_(live|test)_[A-Za-z0-9_-]+' | tail -1 || true)"
         PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
@@ -125,6 +149,15 @@ runs:
         SEEDED_CODE="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_VERIFICATION_CODE=[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         if [[ "$SEEDED_CODE" != "$VERIFICATION_CODE" ]]; then
           echo "::error::Customer fixtures were not seeded (expected code '${VERIFICATION_CODE}', got '${SEEDED_CODE}'). Tinker output:"
+          printf '%s\n' "$OUT"
+          exit 1
+        fi
+        # The Drivers folder's auth flows depend on the seeded driver in the same way.
+        # The snippet only reaches this echo if the Driver record was created, so a missing
+        # line means driver auth would fail with an opaque 401/400 across four requests.
+        SEEDED_DRIVER="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_DRIVER_IDENTITY=\S+' | tail -1 | cut -d= -f2 || true)"
+        if [[ "$SEEDED_DRIVER" != "$DRIVER_IDENTITY" ]]; then
+          echo "::error::Driver fixtures were not seeded (expected '${DRIVER_IDENTITY}', got '${SEEDED_DRIVER}'). Tinker output:"
           printf '%s\n' "$OUT"
           exit 1
         fi
@@ -198,6 +231,9 @@ runs:
         CUSTOMER_PASSWORD: ${{ inputs.customer-password }}
         CUSTOMER_PHONE: ${{ inputs.customer-phone }}
         VERIFICATION_CODE: ${{ inputs.customer-verification-code }}
+        DRIVER_IDENTITY: ${{ inputs.driver-identity }}
+        DRIVER_PASSWORD: ${{ inputs.driver-password }}
+        DRIVER_PHONE: ${{ inputs.driver-phone }}
       run: |
         set -uo pipefail
         overall=0
@@ -244,6 +280,10 @@ runs:
           '  --env-var "customer_password=${CUSTOMER_PASSWORD}" \' \
           '  --env-var "customer_phone=${CUSTOMER_PHONE}" \' \
           '  --env-var "verification_code=${VERIFICATION_CODE}" \' \
+          '  --env-var "driver_identity=${DRIVER_IDENTITY}" \' \
+          '  --env-var "driver_password=${DRIVER_PASSWORD}" \' \
+          '  --env-var "driver_phone=${DRIVER_PHONE}" \' \
+          '  --env-var "device_token=ci-contract-device-token" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"
         chmod +x "$RUNNER"

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -172,6 +172,78 @@ try {
         echo 'MINTED_STOREFRONT_KEY=' . PHP_EOL;
     }
 
+    /* ============================================================
+     | DRIVER FIXTURES (Fleetbase API / Drivers)
+     * ============================================================ */
+
+    // Login Driver resolves a User by phone OR email that HAS a related driver:
+    //   User::where(phone = static::phone($identity))->orWhere('email', $identity)
+    //       ->whereHas('driver')
+    // so the User alone is not enough — a Driver row scoped to the same company is
+    // required or every driver auth request fails before it reaches a password check.
+    $driverIdentity = getenv('CI_DRIVER_IDENTITY') ?: 'ci-driver@fleetbase.local';
+    $driverPhone    = getenv('CI_DRIVER_PHONE') ?: '+15555550124';
+    $driverPassword = getenv('CI_DRIVER_PASSWORD') ?: 'CiDriverPassw0rd!';
+
+    $driverUser = \Fleetbase\Models\User::where('email', $driverIdentity)->withoutGlobalScopes()->first();
+    if (!$driverUser) {
+        $driverUser               = new \Fleetbase\Models\User();
+        $driverUser->email        = $driverIdentity;
+        $driverUser->company_uuid = $company->uuid;
+    }
+    // Reasserted on every run: Switch Driver Organization and the profile updates mutate
+    // these, and the collection expects a known starting state.
+    $driverUser->name   = 'Casey Driver';
+    $driverUser->phone  = $driverPhone;
+    $driverUser->type   = 'user';
+    $driverUser->status = 'active';
+    $driverUser->password = $driverPassword;
+    $driverUser->save();
+
+    if (class_exists(\Fleetbase\FleetOps\Models\Driver::class)) {
+        $driverRecord = \Fleetbase\FleetOps\Models\Driver::withoutGlobalScopes()
+            ->where(['user_uuid' => $driverUser->uuid, 'company_uuid' => $company->uuid])
+            ->first();
+
+        if (!$driverRecord) {
+            $driverRecord = \Fleetbase\FleetOps\Models\Driver::create([
+                'user_uuid'    => $driverUser->uuid,
+                'company_uuid' => $company->uuid,
+                'status'       => 'active',
+                'online'       => 0,
+            ]);
+        }
+
+        echo 'SEEDED_DRIVER_ID=' . $driverRecord->fresh()->public_id . PHP_EOL;
+
+        // POST /v1/drivers/register-device (the route with no {id}) resolves the driver
+        // from $request->user(). Under `fleetbase.api` that is the API credential's owner,
+        // not the driver seeded above — so the route is unreachable unless the credential
+        // owner is itself a driver. That is a real configuration (an owner-operator), and
+        // it is the only way an org-key contract run can exercise the tokenless route.
+        \Fleetbase\FleetOps\Models\Driver::firstOrCreate(
+            ['user_uuid' => $user->uuid, 'company_uuid' => $company->uuid],
+            ['status' => 'active', 'online' => 0]
+        );
+    } else {
+        echo '::warning::FleetOps not installed; driver fixtures skipped.' . PHP_EOL;
+    }
+
+    // verifyCode defaults `for` to driver_login and matches on subject + code + for,
+    // mirroring the customer login code above.
+    \Fleetbase\Models\VerificationCode::withoutGlobalScopes()
+        ->where(['subject_uuid' => $driverUser->uuid, 'for' => 'driver_login'])
+        ->delete();
+    $driverCode             = \Fleetbase\Models\VerificationCode::generateFor($driverUser, 'driver_login', false);
+    $driverCode->expires_at = \Illuminate\Support\Carbon::now()->addDay();
+    $driverCode->status     = 'active';
+    $driverCode->save();
+    $driverCode->code = $customerCode;
+    $driverCode->save();
+
+    echo 'SEEDED_DRIVER_IDENTITY=' . $driverIdentity . PHP_EOL;
+    echo 'SEEDED_DRIVER_PHONE=' . $driverPhone . PHP_EOL;
+
     echo 'SEEDED_CUSTOMER_IDENTITY=' . $customerIdentity . PHP_EOL;
     echo 'SEEDED_CUSTOMER_PHONE=' . $customerPhone . PHP_EOL;
     echo 'SEEDED_VERIFICATION_CODE=' . $customerCode . PHP_EOL;


### PR DESCRIPTION
The Drivers folder's auth requests had no fixture to authenticate against, so four of them failed on every contract run. `DriverController::login` resolves a User by phone OR email that `whereHas('driver')` — a User alone is not enough, a `Driver` row scoped to the same company is required or the request fails before it reaches the password check.

## What this seeds

Mirroring the existing customer fixtures in `scripts/ci/mint-api-key.php`:

- a driver `User` with a known email, phone and password
- a `Driver` record in the CI company
- a `driver_login` `VerificationCode` using the same `000000` code

It also gives the **API credential's owner** a driver profile. `POST /v1/drivers/register-device` (the route with no `{id}`) resolves the driver from the authenticated user, which under `fleetbase.api` is the credential owner — so an org key can never reach that route unless its owner is itself a driver. That is a real configuration (an owner-operator), and it is the only way an org-key run can exercise the tokenless route at all.

## Action changes

New `driver-identity` / `driver-password` / `driver-phone` inputs, passed to the seed via `docker compose exec -e` and injected as `{{driver_identity}}`, `{{driver_password}}` and `{{driver_phone}}` — the same single-source-of-truth arrangement the customer values already use. Plus `{{device_token}}`, which both register-device requests reference and nothing set.

A guard fails the step when the driver fixtures did not land, so these four requests cannot silently regress to an opaque 401/400 the way the customer folder once did.

## Verified against a live stack

| request | before | after |
| --- | --- | --- |
| Login Driver | 401 | **200** |
| Request Driver Login SMS | 400 | **200** |
| Verify Driver Login Code | 400 | **200** |
| Register Device | 404 | **200** |
| Register Driver Device | 500 | **200** |

The last two also needed two fleetops bugs fixed (see fleetbase/fleetops on `dev-v0.6.60`): Laravel never injects a class-typed parameter that declares a default, so `registerDevice()` always ran with `$request === null`; and `currentDriver()` read `$request->user()`, which the public API never populates.

`Switch Driver Organization` still fails 400 — *"Driver is already on this organizations session."* It is honest: the request switches to `{{organization_id}}`, the org the driver is already in. Covering it needs a driver with membership in a second organization, which no public endpoint can create. Tracked separately rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)