### PR TITLE
ci(api-contract): give the contract stack a working mail transport

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -195,6 +195,34 @@ jobs:
 
           bash scripts/docker-install.sh --non-interactive
 
+          # The verification-code endpoints deliver by SMS and fall back to email. With
+          # no mail transport configured the fallback dies on a null from-address —
+          # "Email \"null\" does not comply with addr-spec of RFC 2822" — so
+          # Request Customer Creation Code, Request Customer Login SMS and Request Driver
+          # Login SMS all answered 400 for a reason that has nothing to do with the API.
+          # The log mailer writes the message to the Laravel log and delivers nothing, so
+          # nothing leaves the runner; the endpoints simply become exercisable.
+          set_env() {
+            if grep -q "^$1=" api/.env; then
+              sed -i "s|^$1=.*|$1=$2|" api/.env
+            else
+              echo "$1=$2" >> api/.env
+            fi
+          }
+          set_env MAIL_MAILER log
+          set_env MAIL_FROM_ADDRESS ci-contract@fleetbase.local
+          # Quoted in .env: an unquoted value with spaces is truncated at the first one.
+          set_env MAIL_FROM_NAME '"Fleetbase API Contract"'
+          echo "Mail transport: log (from ci-contract@fleetbase.local)"
+          # After the installer, not before: docker-install.sh writes MAIL_* itself
+          # (MAIL_FROM_ADDRESS="") and would overwrite anything set earlier. The stack
+          # is already up by this point, so the config cache has to be dropped.
+          docker compose exec -T application php artisan config:clear >/dev/null 2>&1 || true
+          # Octane holds a booted application in each worker, so clearing the cached
+          # config file is not enough — the workers have to be recycled to re-read .env.
+          docker compose exec -T application php artisan octane:reload >/dev/null 2>&1 || true
+
+
       - name: Wait for API health
         run: |
           set -uo pipefail


### PR DESCRIPTION
Three requests in the fleetops collection fail for a reason that has nothing to do with the API under test. The verification-code endpoints deliver by SMS and fall back to email, and the contract stack has no usable from-address, so the fallback dies inside Symfony:

| request | status | error |
| --- | --- | --- |
| Request Customer Creation Code | 400 | `Email "null" does not comply with addr-spec of RFC 2822` |
| Request Customer Login SMS | 400 | `Unable to send verification code.` |
| Request Driver Login SMS | 400 | `Unable to send SMS Verification code.` |

## Where the bad address comes from

`api/.env.example` ships `MAIL_FROM_ADDRESS=null` — the literal four-character string. `config/mail.php` reads `env('MAIL_FROM_ADDRESS', 'hello@fleetbase.io')`, and a present-but-garbage value overrides the default rather than falling back to it. `docker-install.sh --non-interactive` then writes an empty value. Either way the address is unusable.

This sets `MAIL_MAILER=log` and a real from-address. The log mailer writes the message to the Laravel log and delivers nothing, so **no mail leaves the runner** — the endpoints simply become exercisable rather than failing before they reach any logic. No assertion is weakened.

## Two placement details that are load-bearing

- **After `docker-install.sh`, not before.** The installer writes `MAIL_*` itself (`env_line "MAIL_FROM_ADDRESS" "$MAIL_FROM_ADDRESS"` with an empty value in non-interactive mode) and would overwrite anything set earlier.
- **Config clear *and* `octane:reload`.** The stack is already up by that point, and each Octane worker holds a booted application — clearing the cached config file alone leaves the workers on the old `.env`.

## Verification

Reproduced on a working stack by setting `MAIL_FROM_ADDRESS=null`: the same endpoint returned the identical `400 Unable to send SMS Verification code.` Restoring a valid address changed the failure, confirming the from-address is what these three die on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)