### PR TITLE
ci(api-contract): seed a ledger invoice so the public-invoice requests resolve

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -135,6 +135,7 @@ runs:
         PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
         ORGANIZATION_ID="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_COMPANY_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         STOREFRONT_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_STOREFRONT_KEY=store_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        INVOICE_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INVOICE_ID=[A-Za-z0-9_]+' | tail -1 | cut -d= -f2 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -180,6 +181,14 @@ runs:
         else
           echo "::warning::No storefront key minted; the Storefront collection will 401."
         fi
+        # The three public-invoice requests are addressed by an invoice public_id and
+        # nothing in the collection can create one — the public API has no invoice
+        # creation endpoint. Absent only means the ledger extension is not installed.
+        if [[ -n "$INVOICE_ID" ]]; then
+          echo "invoice_public_id=$INVOICE_ID" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::No invoice seeded; the Ledger public-invoice requests will 404."
+        fi
         if [[ -n "$PLATFORM_TOKEN" ]]; then
           echo "::add-mask::$PLATFORM_TOKEN"
           echo "platform_token=$PLATFORM_TOKEN" >> "$GITHUB_OUTPUT"
@@ -224,6 +233,7 @@ runs:
         PLATFORM_TOKEN: ${{ steps.key.outputs.platform_token }}
         STOREFRONT_KEY: ${{ steps.key.outputs.storefront_key }}
         ORGANIZATION_ID: ${{ steps.key.outputs.organization_id }}
+        INVOICE_PUBLIC_ID: ${{ steps.key.outputs.invoice_public_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
         NAMESPACE: ${{ inputs.namespace }}
@@ -294,6 +304,7 @@ runs:
           '  --env-var "driver_password=${DRIVER_PASSWORD}" \' \
           '  --env-var "driver_phone=${DRIVER_PHONE}" \' \
           '  --env-var "device_token=ci-contract-device-token" \' \
+          '  --env-var "invoice_public_id=${INVOICE_PUBLIC_ID}" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"
         chmod +x "$RUNNER"

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -244,6 +244,53 @@ try {
     echo 'SEEDED_DRIVER_IDENTITY=' . $driverIdentity . PHP_EOL;
     echo 'SEEDED_DRIVER_PHONE=' . $driverPhone . PHP_EOL;
 
+    /* ============================================================
+     | LEDGER INVOICE FIXTURE (Fleetbase Ledger API / Public Invoices)
+     * ============================================================ */
+
+    // The three public-invoice endpoints are addressed by an invoice public_id, and
+    // {{invoice_public_id}} is set by nothing — no request in the collection creates an
+    // invoice, because the public API exposes no invoice-creation endpoint. Seeding one
+    // is the only way to reach them.
+    //
+    // Status is deliberately NOT 'draft': PublicInvoiceController::show answers 403 for
+    // draft invoices ("not yet available"), so a draft would exercise the guard rather
+    // than the endpoint. 'sent' also lets show() transition it to 'viewed' on first
+    // access, which is the behaviour worth covering.
+    if (class_exists(\Fleetbase\Ledger\Models\Invoice::class)) {
+        $invoice = \Fleetbase\Ledger\Models\Invoice::withoutGlobalScopes()
+            ->where(['company_uuid' => $company->uuid, 'number' => 'CI-CONTRACT-0001'])
+            ->first();
+
+        if (!$invoice) {
+            $invoice = \Fleetbase\Ledger\Models\Invoice::create([
+                'company_uuid'    => $company->uuid,
+                'created_by_uuid' => $user->uuid,
+                'number'          => 'CI-CONTRACT-0001',
+                'date'            => \Illuminate\Support\Carbon::now()->toDateString(),
+                'due_date'        => \Illuminate\Support\Carbon::now()->addDays(30)->toDateString(),
+                'subtotal'        => 10000,
+                'tax'             => 0,
+                'total_amount'    => 10000,
+                'amount_paid'     => 0,
+                'balance'         => 10000,
+                'currency'        => 'USD',
+                'status'          => 'sent',
+                'notes'           => 'Seeded by the API contract run.',
+            ]);
+        }
+
+        // Reasserted on reruns: show() flips `sent` to `viewed` on first access, and a
+        // later run would otherwise start from whatever the previous one left behind.
+        $invoice->status    = 'sent';
+        $invoice->viewed_at = null;
+        $invoice->save();
+
+        echo 'SEEDED_INVOICE_ID=' . $invoice->fresh()->public_id . PHP_EOL;
+    } else {
+        echo '::warning::Ledger not installed; the invoice fixture was skipped.' . PHP_EOL;
+    }
+
     echo 'SEEDED_CUSTOMER_IDENTITY=' . $customerIdentity . PHP_EOL;
     echo 'SEEDED_CUSTOMER_PHONE=' . $customerPhone . PHP_EOL;
     echo 'SEEDED_VERIFICATION_CODE=' . $customerCode . PHP_EOL;


### PR DESCRIPTION
The three **Public Invoices** requests are addressed by `{{invoice_public_id}}`, and nothing sets it. The public API has no invoice-creation endpoint, so no request in the collection can produce one — all three 404 on every run. Seeding is the only way to reach them.

## Why `status = 'sent'`

`PublicInvoiceController::show()` answers **403** for draft invoices (*"This invoice is not yet available"*), so a draft fixture would exercise the guard rather than the endpoint. `sent` also lets `show()` perform its `sent → viewed` transition, which is the behaviour actually worth covering.

Both `status` and `viewed_at` are reasserted on every run, precisely because of that transition — a rerun would otherwise start from whatever the previous run left behind.

## Scope

Guarded on `class_exists` with a warning rather than an error when the extension is absent, matching how the storefront store fixture already behaves — ledger is not installed in every stack that runs this workflow.

Pairs with [ledger 7605441](https://github.com/fleetbase/ledger/commit/7605441), which fixes the four `/ledger/v1/wallet*` routes. Those were failing for an unrelated and more serious reason: `$request->user()` is null on every public API request, so they answered 401 to *every* credential — including a driver's own Sanctum token. Verified 401 → 200 against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)