### PR TITLE
ci(api-contract): seed a test-mode Stripe gateway for checkout and top-up

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -72,6 +72,19 @@ inputs:
       ::add-mask:: for the same secrets.
     required: false
     default: 'true'
+  stripe-publishable-key:
+    description: >-
+      Stripe TEST publishable key (pk_test_). Seeded into the storefront and ledger
+      gateway rows so the checkout and top-up paths are reachable.
+    required: false
+    default: ''
+  stripe-secret-key:
+    description: >-
+      Stripe TEST secret key (sk_test_). When empty no gateway is seeded and the
+      gateway-backed requests report the gateway as unconfigured, which is the
+      correct result for a fork without the org secrets.
+    required: false
+    default: ''
   postman-ref:
     description: Ref of the fleetbase/postman repo to check out.
     required: false
@@ -111,8 +124,15 @@ runs:
         DRIVER_IDENTITY: ${{ inputs.driver-identity }}
         DRIVER_PASSWORD: ${{ inputs.driver-password }}
         DRIVER_PHONE: ${{ inputs.driver-phone }}
+        STRIPE_PUBLISHABLE_KEY: ${{ inputs.stripe-publishable-key }}
+        STRIPE_SECRET_KEY: ${{ inputs.stripe-secret-key }}
       run: |
         set -uo pipefail
+        # Masked before it is ever passed on: the seed echoes gateway ids, and --verbose
+        # captures request and response bodies into the uploaded artifact.
+        if [[ -n "${STRIPE_SECRET_KEY:-}" ]]; then
+          echo "::add-mask::${STRIPE_SECRET_KEY}"
+        fi
         # Run the mint snippet via `tinker --execute="eval(base64_decode(...))"`.
         # Piping a file with a <?php tag to tinker triggers a PsySH parse error, and
         # inlining the code would let the shell expand its $variables — base64+eval
@@ -130,6 +150,8 @@ runs:
           -e "CI_DRIVER_IDENTITY=${DRIVER_IDENTITY}" \
           -e "CI_DRIVER_PHONE=${DRIVER_PHONE}" \
           -e "CI_DRIVER_PASSWORD=${DRIVER_PASSWORD}" \
+          -e "CI_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}" \
+          -e "CI_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}" \
           application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
         KEY="$(printf '%s\n' "$OUT" | grep -oE 'flb_(live|test)_[A-Za-z0-9_-]+' | tail -1 || true)"
         PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
@@ -426,6 +448,7 @@ runs:
             sed -i -E \
               -e 's/(Authorization:[[:space:]]*Bearer[[:space:]]*)[A-Za-z0-9._-]+/\1<redacted>/gi' \
               -e 's/(flb_(live|test|platform)_)[A-Za-z0-9_-]+/\1<redacted>/g' \
+            -e 's/((sk|rk|pk)_(live|test)_)[A-Za-z0-9]+/\1<redacted>/g' \
               "$f"
           done
 

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -313,6 +313,10 @@ jobs:
           postman-ref: ${{ inputs.postman-ref }}
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
           github-token: ${{ secrets._GITHUB_AUTH_TOKEN }}
+          # TEST-mode keys only. The live pair also exists in the org secrets and must
+          # never be referenced here — a contract run creates payment intents.
+          stripe-publishable-key: ${{ secrets.STRIPE_TEST_KEY }}
+          stripe-secret-key: ${{ secrets.STRIPE_TEST_SECRET }}
 
       - name: Dump logs on failure
         if: failure()

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -245,6 +245,82 @@ try {
     echo 'SEEDED_DRIVER_PHONE=' . $driverPhone . PHP_EOL;
 
     /* ============================================================
+     | STRIPE TEST GATEWAY (Storefront checkout + Ledger top-up)
+     * ============================================================ */
+
+    // Stripe is configured by a Gateway ROW, not by env vars: Storefront resolves it with
+    // Storefront::findGateway('stripe') scoped to the store, then reads
+    // $gateway->config->secret_key. With no row the checkout chain answers
+    // "Stripe not setup." and the ledger top-up answers "No query results for Gateway".
+    //
+    // Both values come from the CI environment and are TEST-mode by contract — the action
+    // passes STRIPE_TEST_KEY / STRIPE_TEST_SECRET. Nothing is seeded when the secret is
+    // absent, so a fork without the org secrets still runs everything else.
+    $stripePublishable = getenv('CI_STRIPE_PUBLISHABLE_KEY') ?: '';
+    $stripeSecret      = getenv('CI_STRIPE_SECRET_KEY') ?: '';
+
+    if ($stripeSecret && isset($store) && class_exists(\Fleetbase\Storefront\Models\Gateway::class)) {
+        $storefrontGateway = \Fleetbase\Storefront\Models\Gateway::withoutGlobalScopes()
+            ->where(['owner_uuid' => $store->uuid, 'code' => 'stripe'])
+            ->first();
+
+        if (!$storefrontGateway) {
+            $storefrontGateway               = new \Fleetbase\Storefront\Models\Gateway();
+            $storefrontGateway->company_uuid = $company->uuid;
+            $storefrontGateway->owner_uuid   = $store->uuid;
+            // Assigned through the mutator, which runs Utils::getMutationType() — every
+            // other writer in the package sets it this way, and storing the FQCN directly
+            // produces a value findGateway's owner scoping will not match.
+            $storefrontGateway->owner_type   = 'storefront:store';
+            $storefrontGateway->code         = 'stripe';
+            $storefrontGateway->type         = 'stripe';
+        }
+
+        $storefrontGateway->created_by_uuid = $user->uuid;
+        $storefrontGateway->name            = 'CI Contract Stripe (test mode)';
+        $storefrontGateway->sandbox         = true;
+        $storefrontGateway->config          = [
+            'public_key' => $stripePublishable,
+            'secret_key' => $stripeSecret,
+        ];
+        $storefrontGateway->save();
+
+        echo 'SEEDED_STOREFRONT_GATEWAY=' . $storefrontGateway->fresh()->public_id . PHP_EOL;
+    }
+
+    if ($stripeSecret && class_exists(\Fleetbase\Ledger\Models\Gateway::class)) {
+        // A different model with a different shape: keyed by `driver` rather than `code`,
+        // and its Stripe driver reads `publishable_key` where Storefront reads
+        // `public_key`. Seeding one does not seed the other.
+        $ledgerGateway = \Fleetbase\Ledger\Models\Gateway::withoutGlobalScopes()
+            ->where(['company_uuid' => $company->uuid, 'driver' => 'stripe'])
+            ->first();
+
+        if (!$ledgerGateway) {
+            $ledgerGateway               = new \Fleetbase\Ledger\Models\Gateway();
+            $ledgerGateway->company_uuid = $company->uuid;
+            $ledgerGateway->driver       = 'stripe';
+        }
+
+        $ledgerGateway->created_by_uuid = $user->uuid;
+        $ledgerGateway->name            = 'CI Contract Stripe (test mode)';
+        $ledgerGateway->is_sandbox      = true;
+        $ledgerGateway->environment     = 'sandbox';
+        $ledgerGateway->status          = 'active';
+        $ledgerGateway->config          = [
+            'publishable_key' => $stripePublishable,
+            'secret_key'      => $stripeSecret,
+        ];
+        $ledgerGateway->save();
+
+        echo 'SEEDED_LEDGER_GATEWAY=' . $ledgerGateway->fresh()->public_id . PHP_EOL;
+    }
+
+    if (!$stripeSecret) {
+        echo '::notice::No Stripe test secret provided; gateway-backed requests will report the gateway as unconfigured.' . PHP_EOL;
+    }
+
+    /* ============================================================
      | LEDGER INVOICE FIXTURE (Fleetbase Ledger API / Public Invoices)
      * ============================================================ */
 


### PR DESCRIPTION
Implements decision 2 for the gateway-backed requests.

Stripe is configured by a **Gateway row**, not by env vars — `Storefront::findGateway('stripe')` scoped to the store, then `$gateway->config->secret_key`. With no row seeded:

| module | request(s) | error |
| --- | --- | --- |
| Storefront | ×3 | `Stripe not setup.` |
| Storefront | ×2 | `Credentials are required to create a Client` |
| Ledger | Top Up Wallet | `No query results for model [...Gateway]` |

plus the checkout chain behind them, since `checkout_id` / `checkout_token` / `payment_intent_id` are captured from those responses.

## Two gateway models, not one

They are **not** interchangeable, and seeding one does not seed the other:

| | storefront | ledger |
| --- | --- | --- |
| keyed on | `code` | `driver` |
| publishable key | `public_key` | `publishable_key` |
| scoped to | the store (`owner_uuid` + polymorphic `owner_type`) | the company |

`owner_type` is assigned through the model's mutator so it runs `Utils::getMutationType()` — every other writer in the package does this, and storing the FQCN directly produces a value the owner scoping will not match.

## Secret handling

Uses `STRIPE_TEST_KEY` / `STRIPE_TEST_SECRET`. **The live pair also exists in the org secrets and is deliberately not referenced** — a contract run creates payment intents.

- `::add-mask::` before the value is passed anywhere, so it cannot surface in the job log.
- The artifact scrub gains `sk_`/`rk_`/`pk_` in both live and test forms. `::add-mask::` does **not** apply to uploaded artifacts, and `--verbose` captures bodies — this is the same gap that made the earlier bearer-token scrub necessary.
- An absent secret seeds nothing, so a fork without the org secrets still runs every other request rather than failing the job.

Verified the scrub against GNU sed: `sk_test_`, `sk_live_`, `pk_test_` and `rk_` forms are all redacted.

## Worth knowing

This is the one change in this effort that makes the contract run depend on a third party. If Stripe is unreachable or rate-limits, these requests fail for a reason that has nothing to do with Fleetbase. That was the stated trade-off when decision 2 was taken; flagging it again because it is the only failure mode of its kind in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)