### PR TITLE
fix(install): non-interactive installs could not send mail at all

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -193,15 +193,22 @@ jobs:
             echo "::notice::GOOGLE_MAPS_API_KEY not set; order shapes that send a street address cannot geocode. Coordinate and GeoJSON shapes are unaffected."
           fi
 
-          bash scripts/docker-install.sh --non-interactive
-
           # The verification-code endpoints deliver by SMS and fall back to email. With
-          # no mail transport configured the fallback dies on a null from-address —
-          # "Email \"null\" does not comply with addr-spec of RFC 2822" — so
-          # Request Customer Creation Code, Request Customer Login SMS and Request Driver
-          # Login SMS all answered 400 for a reason that has nothing to do with the API.
-          # The log mailer writes the message to the Laravel log and delivers nothing, so
-          # nothing leaves the runner; the endpoints simply become exercisable.
+          # no usable from-address the fallback dies inside Symfony —
+          #   Email "null" does not comply with addr-spec of RFC 2822
+          # — which surfaced as 400s on three requests and a 500 on Send Work Order.
+          #
+          # api/.env.example ships the literal string MAIL_FROM_ADDRESS=null, which
+          # OVERRIDES config/mail.php's default rather than falling back to it.
+          #
+          # This must run BEFORE the installer brings the stack up. Laravel parses .env
+          # once at boot, and an earlier attempt to set it afterwards did not take:
+          # config:clear and octane:reload both ran and the endpoints still answered
+          # Email "null", because the workers were already holding the parsed values.
+          #
+          # The log mailer delivers nothing, so no mail leaves the runner; the endpoints
+          # simply become exercisable. MAIL_MAILER is already log via the installer's
+          # generated compose override.
           set_env() {
             if grep -q "^$1=" api/.env; then
               sed -i "s|^$1=.*|$1=$2|" api/.env
@@ -211,16 +218,10 @@ jobs:
           }
           set_env MAIL_MAILER log
           set_env MAIL_FROM_ADDRESS ci-contract@fleetbase.local
-          # Quoted in .env: an unquoted value with spaces is truncated at the first one.
-          set_env MAIL_FROM_NAME '"Fleetbase API Contract"'
           echo "Mail transport: log (from ci-contract@fleetbase.local)"
-          # After the installer, not before: docker-install.sh writes MAIL_* itself
-          # (MAIL_FROM_ADDRESS="") and would overwrite anything set earlier. The stack
-          # is already up by this point, so the config cache has to be dropped.
-          docker compose exec -T application php artisan config:clear >/dev/null 2>&1 || true
-          # Octane holds a booted application in each worker, so clearing the cached
-          # config file is not enough — the workers have to be recycled to re-read .env.
-          docker compose exec -T application php artisan octane:reload >/dev/null 2>&1 || true
+
+          bash scripts/docker-install.sh --non-interactive
+
 
 
       - name: Wait for API health

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -164,7 +164,17 @@ section "Mail Configuration"
 
 MAIL_MAILER="log"
 MAIL_HOST=""; MAIL_PORT=""; MAIL_USERNAME=""; MAIL_PASSWORD=""
-MAIL_FROM_ADDRESS=""; MAIL_FROM_NAME="$APP_NAME"
+# Non-empty on purpose. env_line() skips empty values, so an empty default means the
+# key never reaches docker-compose.override.yml — and api/.env.example ships the literal
+# string MAIL_FROM_ADDRESS=null, which then OVERRIDES config/mail.php's default rather
+# than falling back to it. Every non-interactive install ended up unable to send mail:
+#
+#   Email "null" does not comply with addr-spec of RFC 2822.
+#
+# which surfaces as a 400 on the verification-code endpoints and a 500 on any notification
+# send. This value matches config/mail.php's own default, so the result is the same as if
+# the key were genuinely unset.
+MAIL_FROM_ADDRESS="hello@fleetbase.io"; MAIL_FROM_NAME="$APP_NAME"
 MAILGUN_DOMAIN=""; MAILGUN_SECRET=""
 POSTMARK_TOKEN=""; SENDGRID_API_KEY=""; RESEND_KEY=""
 


### PR DESCRIPTION
Supersedes the mechanism in #591, which **did not work** — I verified against a real run: the step logged `Mail transport: log`, and the five affected requests failed unchanged with the same error. This fixes the actual cause.

## The bug

`scripts/docker-install.sh` writes its values into `docker-compose.override.yml` through `env_line()`, which **skips empty values**:

```bash
env_line() {
  local key="$1" val="$2"
  [[ -z "$val" ]] && return
  ...
}
```

`MAIL_FROM_ADDRESS` defaulted to `""`, so the key never reached the container environment. Laravel then fell back to `api/.env`, which is copied from `.env.example` — and that ships the **literal string** `MAIL_FROM_ADDRESS=null`, which *overrides* `config/mail.php`'s `env('MAIL_FROM_ADDRESS', 'hello@fleetbase.io')` rather than falling back to it.

So every non-interactive install ran with an unusable from-address:

```
Email "null" does not comply with addr-spec of RFC 2822.
```

**This is not a CI-only problem.** It is a 400 on every verification-code endpoint and a 500 on any notification send — password resets, login codes, work orders — for anyone who ran the non-interactive installer.

## The fix

The default now matches `config/mail.php`'s own, so the result is identical to the key being genuinely unset.

## Why #591's placement failed

It set the value *after* `docker-install.sh`, on the assumption the installer would clobber an earlier write. It does not — it writes to the compose override, never to `api/.env`. But by then the stack was already up, and **Laravel parses `.env` once at boot**. `config:clear` and `octane:reload` both ran and neither helped; the workers were already holding the parsed values. The block now runs before the installer brings the stack up.

## Expected effect on the contract run

Five fleetops requests, currently failing at 172/189:

| request | current |
| --- | --- |
| Request Customer Creation Code | 400 |
| Request Customer Login SMS | 400 |
| Request Driver Login SMS | 400 |
| Forgot Customer Password | 400 |
| Send Work Order | **500** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)