### PR TITLE
ci(api-contract): inject the proof base64 the capture endpoints need

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -278,6 +278,10 @@ runs:
         #     Update Authenticated Customer is a no-op rename rather than a surprise.
         # verification_code must equal what mint-api-key.php seeded — both read the same
         # action input, so they cannot drift.
+        # proof_photo_base64 / proof_signature_base64 are an 8x8 PNG. Capture Photo
+        # validates with base64_decode($value, true), so a data: URI prefix would fail
+        # the strict decode — this is bare base64 — and the bytes are a real image
+        # because the same rule also accepts an uploaded file and checks its dimensions.
         printf '%s\n' \
           '#!/usr/bin/env bash' \
           '# The CLI resolves a formdata `src` against its own process working directory,' \
@@ -304,6 +308,8 @@ runs:
           '  --env-var "driver_password=${DRIVER_PASSWORD}" \' \
           '  --env-var "driver_phone=${DRIVER_PHONE}" \' \
           '  --env-var "device_token=ci-contract-device-token" \' \
+          '  --env-var "proof_photo_base64=iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAbElEQVR42hXNQRUAUQhCUaMYhShGeVGIQhSizB+XXA7ODDtouIHBQ4YOM8suWm5h8ZKl+0CskDiBsIioHhx76LiDw0eO3oN/4FVf+J8h0PduzBqZ8x/bxNQPwgaFy192SGgelC0q13/CJaXlA8Z7WAFXOTbyAAAAAElFTkSuQmCC" \' \
+          '  --env-var "proof_signature_base64=iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAbElEQVR42hXNQRUAUQhCUaMYhShGeVGIQhSizB+XXA7ODDtouIHBQ4YOM8suWm5h8ZKl+0CskDiBsIioHhx76LiDw0eO3oN/4FVf+J8h0PduzBqZ8x/bxNQPwgaFy192SGgelC0q13/CJaXlA8Z7WAFXOTbyAAAAAElFTkSuQmCC" \' \
           '  --env-var "invoice_public_id=${INVOICE_PUBLIC_ID}" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"


### PR DESCRIPTION
`Capture Photo for Order` referenced `{{proof_photo_base64}}`, which nothing set, so the unresolved literal reached the validator: **`photos.0 is not a valid Base64 string.`** `Capture Signature for Order` needs the same value once the collection stops sending an empty signature (fleetbase/postman#28).

Both are injected as an 8×8 PNG.

Two details that matter:

- **Bare base64, not a data: URI.** The rule validates with `base64_decode($value, true)`, and a `data:image/png;base64,` prefix fails that strict decode.
- **Real image bytes, not arbitrary base64.** The same rule also accepts an uploaded file and checks its dimensions and size, so a decodable-but-not-an-image string would pass one branch and fail elsewhere.

Pairs with fleetbase/postman#28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)