### PR TITLE
ci(api-contract): fix two run-ordering faults in the contract runner

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -46,6 +46,20 @@ import os, re, sys
 # succeeds once that has run. Pinning it to the head of the tail puts it after
 # Update Authenticated Customer (order 9000) while keeping it before the logouts.
 # It is a public route, so it needs no token.
+# Deletes are deferred as a batch, and within that batch they keep folder order —
+# which can delete a parent before its children. Zones carry a service_area, so
+# Delete a Service Area (Service Areas sorts before Zones) cascaded the zone away and
+# Delete a Zone then answered "Zone resource not found." — a 404 manufactured entirely
+# by this script's own ordering, not by the API.
+#
+# Listed paths sort to the FRONT of the delete batch, in the order given. Add a child
+# here whenever its parent's delete would remove it.
+DELETE_FIRST = {
+    'Fleetbase API': [
+        'Zones/Delete a Zone',            # cascades with Service Areas/Delete a Service Area
+    ],
+}
+
 RUN_LAST = {
     'Fleetbase API': [
         'Customers/Request Customer Login SMS',     # needs User.phone restored by Update Me
@@ -66,6 +80,7 @@ def field(path, key, default=None):
 
 # Pinned order for this collection, as {path: index}. Unknown collection => {}.
 run_last = {p: i for i, p in enumerate(RUN_LAST.get(os.path.basename(root.rstrip('/')), []))}
+delete_first = {p: i for i, p in enumerate(DELETE_FIRST.get(os.path.basename(root.rstrip('/')), []))}
 
 def line_value(path, key):
     """Read a scalar whose value may contain spaces, e.g. `name: A long title`.
@@ -110,6 +125,11 @@ for folder in os.listdir(root):
             # order of phases 1 and 2 is inert today — but a future RUN_LAST
             # entry that depends on a record a DELETE removes would need this.
             phase, primary, secondary = 2, run_last[path], 0
+            sort_folder = ''
+        elif method == 'DELETE' and path in delete_first:
+            # Negative primary sorts ahead of every folder-ordered delete, since
+            # forder is always non-negative.
+            phase, primary, secondary = 1, delete_first[path] - len(delete_first), 0
             sort_folder = ''
         else:
             phase, primary, secondary = (1 if method == 'DELETE' else 0), forder, rorder

--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -54,6 +54,19 @@ import os, re, sys
 #
 # Listed paths sort to the FRONT of the delete batch, in the order given. Add a child
 # here whenever its parent's delete would remove it.
+# Requests whose dependency lives in a LATER folder. The published collection's folder
+# order is documentation, not a dependency graph — Cart sorts before Products, so
+# Add Item to Cart fired before Create Product ever ran and {{product_id}} was unset,
+# giving "Invalid product provided". These run after every ordinary request but BEFORE
+# the deletes, in the order listed here.
+RUN_LATE = {
+    'Fleetbase Storefront API': [
+        'Cart/Add Item to Cart',        # needs {{product_id}} from Products/Create Product
+        'Cart/Update item in Cart',     # needs the line item Add Item to Cart creates
+        'Cart/Remove item from cart',   # ditto
+    ],
+}
+
 DELETE_FIRST = {
     'Fleetbase API': [
         'Zones/Delete a Zone',            # cascades with Service Areas/Delete a Service Area
@@ -81,6 +94,7 @@ def field(path, key, default=None):
 # Pinned order for this collection, as {path: index}. Unknown collection => {}.
 run_last = {p: i for i, p in enumerate(RUN_LAST.get(os.path.basename(root.rstrip('/')), []))}
 delete_first = {p: i for i, p in enumerate(DELETE_FIRST.get(os.path.basename(root.rstrip('/')), []))}
+run_late = {p: i for i, p in enumerate(RUN_LATE.get(os.path.basename(root.rstrip('/')), []))}
 
 def line_value(path, key):
     """Read a scalar whose value may contain spaces, e.g. `name: A long title`.
@@ -119,20 +133,23 @@ for folder in os.listdir(root):
         path = f'{folder}/{name}'
         seen.add(path)
         if path in run_last:
-            # Phase 2 sorts after the DELETEs: "pinned last" means last, and
+            # Phase 3 sorts after the DELETEs: "pinned last" means last, and
             # explicit intent beats the heuristic. Nothing in Fleetbase API
             # currently deletes the customer's Contact or User, so the relative
             # order of phases 1 and 2 is inert today — but a future RUN_LAST
             # entry that depends on a record a DELETE removes would need this.
-            phase, primary, secondary = 2, run_last[path], 0
+            phase, primary, secondary = 3, run_last[path], 0
             sort_folder = ''
         elif method == 'DELETE' and path in delete_first:
             # Negative primary sorts ahead of every folder-ordered delete, since
             # forder is always non-negative.
-            phase, primary, secondary = 1, delete_first[path] - len(delete_first), 0
+            phase, primary, secondary = 2, delete_first[path] - len(delete_first), 0
+            sort_folder = ''
+        elif path in run_late:
+            phase, primary, secondary = 1, run_late[path], 0
             sort_folder = ''
         else:
-            phase, primary, secondary = (1 if method == 'DELETE' else 0), forder, rorder
+            phase, primary, secondary = (2 if method == 'DELETE' else 0), forder, rorder
             sort_folder = folder
         items.append((phase, primary, sort_folder, secondary, name, path))
 


### PR DESCRIPTION
Two failures the contract runner **manufactured itself**, neither of them API or collection defects.

## 1. Deletes removed parents before their children

`Delete a Zone` answered `404 "Zone resource not found."` Deletes are deferred to the end as a batch, and within that batch they keep folder order — `Service Areas` sorts before `Zones`, so `Delete a Service Area` ran first and cascaded the zone away.

What gave it away: `Create a Zone` (201), `Query Zones` (200) and `Update a Zone` (200) all passed in the same run against the same id. Only the delete failed, and only because of when it ran.

`DELETE_FIRST` sorts listed paths to the front of the delete batch. Only `Zones/Delete a Zone` needs it today.

## 2. Requests ran before the folder that creates what they need

`Add Item to Cart` answered `"Invalid product provided"`. The Storefront collection puts `Cart` before `Products`, so it fired at position 2 while `Create Product` — the only thing that sets `{{product_id}}` — ran at position 7. `Update item in Cart` and `Remove item from cart` failed behind it with `"Invalid cart item provided to cart!"`.

The published folder order is documentation, not a dependency graph, and it is not ours to reorder. `RUN_LATE` defers the three affected requests instead: after every ordinary request, but **before** the deletes, so `Delete Cart` still tears down the cart they used.

Phases are renumbered to make room — ordinary 0, late 1, delete 2, `RUN_LAST` 3.

## Verification

Across all four collections, the emitted request set is unchanged — 189/60/24/8 in, the same out, sorted diffs empty. So only ordering moved; nothing was dropped, duplicated or renamed.

- `Delete a Zone` now at 162, `Delete a Service Area` at 164
- `Create Product` at 5, `Add Item to Cart` at 56, `Delete Cart` at 59

🤖 Generated with [Claude Code](https://claude.com/claude-code)