### PR TITLE
ci(api-contract): defer Update an Order past the service quotes

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -60,6 +60,9 @@ import os, re, sys
 # giving "Invalid product provided". These run after every ordinary request but BEFORE
 # the deletes, in the order listed here.
 RUN_LATE = {
+    'Fleetbase API': [
+        'Orders/Update an Order',       # needs {{service_quote_id}} from Service Quotes/Query Service Quotes
+    ],
     'Fleetbase Storefront API': [
         'Cart/Add Item to Cart',        # needs {{product_id}} from Products/Create Product
         'Cart/Update item in Cart',     # needs the line item Add Item to Cart creates


### PR DESCRIPTION
`Update an Order` sends `{"service_quote": "{{service_quote_id}}"}` and answered *"The selected service quote is invalid."* — the variable was still unresolved.

`Query Service Quotes` is the only thing that sets it, and it lives in a later folder: `Update an Order` ran at position **91**, `Query Service Quotes` at **147**.

Exactly the same shape as the Cart/Products case `RUN_LATE` was added for in #598, so it uses that mechanism rather than reordering the published collection.

After: `Query Service Quotes` 147 → `Update an Order` 161 → `Delete an Order` 174. After its dependency, still before the order is torn down. Request set unchanged at 189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)