### PR TITLE
ci(api-contract): order the checkout chain and fix two storefront fixtures

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -336,6 +336,7 @@ runs:
           '  --env-var "customer_name=Jane Customer" \' \
           '  --env-var "customer_password=${CUSTOMER_PASSWORD}" \' \
           '  --env-var "customer_phone=${CUSTOMER_PHONE}" \' \
+          '  --env-var "new_customer_identity=ci-new-customer@fleetbase.local" \' \
           '  --env-var "verification_code=${VERIFICATION_CODE}" \' \
           '  --env-var "driver_identity=${DRIVER_IDENTITY}" \' \
           '  --env-var "driver_password=${DRIVER_PASSWORD}" \' \

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -150,8 +150,30 @@ try {
     //   storefront_create_customer   ::create            code + for + meta->identity
     //   storefront_account_closure   ::confirmClosure    code + for + meta->identity
     $seedVerificationCode('storefront_login');
-    $seedVerificationCode('storefront_create_customer', ['identity' => $customerIdentity]);
-    $seedVerificationCode('storefront_account_closure', ['identity' => $customerIdentity]);
+    // Filed under the PHONE, not the email: confirmAccountClosure computes the identity it
+    // looks up as `$user->phone ?? $user->email`, and the seeded customer has a phone. A
+    // code filed under the email was never found — "Invalid verification code provided!".
+    $seedVerificationCode('storefront_account_closure', ['identity' => $customerPhone]);
+
+    // Create a Customer needs an identity with NO existing contact: the request validates
+    // `email` with Rule::unique('contacts'), and by the time it runs the seeded customer's
+    // contact exists — "The email has already been taken." So the creation code is filed
+    // under a second identity reserved for exactly that, and deliberately left without a
+    // contact of its own.
+    $newCustomerIdentity = getenv('CI_NEW_CUSTOMER_IDENTITY') ?: 'ci-new-customer@fleetbase.local';
+
+    \Fleetbase\Models\VerificationCode::withoutGlobalScopes()
+        ->where(['subject_uuid' => $customer->uuid, 'for' => 'storefront_create_customer'])
+        ->delete();
+    $createCode             = \Fleetbase\Models\VerificationCode::generateFor($customer, 'storefront_create_customer', false);
+    $createCode->expires_at = \Illuminate\Support\Carbon::now()->addDay();
+    $createCode->meta       = ['identity' => $newCustomerIdentity];
+    $createCode->status     = 'active';
+    $createCode->save();
+    $createCode->code       = $customerCode;
+    $createCode->save();
+
+    echo 'SEEDED_NEW_CUSTOMER_IDENTITY=' . $newCustomerIdentity . PHP_EOL;
 
     // The Storefront API authenticates with a store/network key, not an organization
     // API credential: SetStorefrontSession rejects any bearer token that does not start

--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -64,9 +64,17 @@ RUN_LATE = {
         'Orders/Update an Order',       # needs {{service_quote_id}} from Service Quotes/Query Service Quotes
     ],
     'Fleetbase Storefront API': [
+        # The cart has to be populated before anything prices or checks out against it,
+        # and emptied only once those are done. Deferring just the three Cart requests
+        # left Checkout running against an empty cart — "The selected cart is invalid."
         'Cart/Add Item to Cart',        # needs {{product_id}} from Products/Create Product
         'Cart/Update item in Cart',     # needs the line item Add Item to Cart creates
-        'Cart/Remove item from cart',   # ditto
+        'Delivery Service Quote/Retrieve a Delivery Service Quote ❗',  # prices the cart
+        'Checkout/Before ❗',                    # needs the cart AND {{service_quote_id}}
+        'Checkout/Capture checkout as order',    # needs {{checkout_token}} from Before
+        'Checkout/Get Checkout Status',          # ditto
+        'Checkout/Update Stripe Payment Intent', # needs the cart and the service quote
+        'Cart/Remove item from cart',   # LAST: it empties what the above depend on
     ],
 }
 


### PR DESCRIPTION
## Checkout ran against an empty cart — my own regression

Deferring only the three Cart requests in #598 left `Checkout/Before` at position 45 while `Add Item to Cart` ran at 56, so it answered *"The selected cart is invalid."* `RUN_LATE` now carries the whole dependent chain, in order:

| | | |
|---|---|---|
| 51 Add Item to Cart | 54 Before | 57 Update Stripe Payment Intent |
| 52 Update item in Cart | 55 Capture checkout as order | 58 Remove item from cart |
| 53 Retrieve a Delivery Service Quote | 56 Get Checkout Status | 59 Delete Cart |

`Remove item from cart` is pinned **last** because it empties what everything above depends on.

## `storefront_account_closure` was filed under the wrong identity

`confirmAccountClosure` computes the identity it looks up as `$user->phone ?? $user->email`, and the seeded customer has a phone — so a code filed under the *email* was never found (*"Invalid verification code provided!"*). Now filed under the phone.

## `Create a Customer` had no usable identity

The request validates `email` with `Rule::unique('contacts')`, and by the time it runs the seeded customer's contact already exists — *"The email has already been taken."*

The creation code is now filed under a **second identity reserved for creation**, seeded deliberately *without* a contact of its own, and injected as `{{new_customer_identity}}`. The collection's `Create a Customer` will need to use that variable — follow-up in fleetbase/postman.

Request set unchanged at 60.

## Storefront progress

23/60 at the start of this work → **42/60** on the last run, before these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)