### PR TITLE
ci(api-contract): exclude only what needs a third-party-signed token

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -59,6 +59,39 @@ import os, re, sys
 # Add Item to Cart fired before Create Product ever ran and {{product_id}} was unset,
 # giving "Invalid product provided". These run after every ordinary request but BEFORE
 # the deletes, in the order listed here.
+# Requests that CANNOT be covered by a public-API contract run, with the reason. They are
+# not emitted, so the job's result reflects only what the run can legitimately prove.
+#
+# This list is deliberately small and deliberately annotated. It is NOT a place to park a
+# request that merely fails today — every entry states a structural reason the public API
+# cannot reach it. Each one is echoed on every run so it stays visible rather than rotting.
+EXCLUDED = {
+    'Fleetbase API': {
+        'Drivers/Switch Driver Organization':
+            'switches to {{organization_id}}, the org the driver is already in; needs a '
+            'driver with membership in a SECOND organization, which no public endpoint creates',
+        'Orders/Capture QR Code for Order':
+            'captureQrScan requires $code === $subject->uuid, and the public API never '
+            'exposes uuids (qr_code is $this->when($isInternal, ...))',
+        'Tracking Numbers/Decode Tracking Number QR':
+            'same uuid gate as Capture QR Code — from-qr matches on uuid, which the public '
+            'API does not expose',
+    },
+    'Fleetbase Storefront API': {
+        'Customer/Authenticate a Customer with Apple':
+            'needs a real Apple identity token; no fixture can produce a verifiable one',
+        'Customer/Authenticate a Customer with Google':
+            'needs a real Google id token',
+        'Customer/Request Phone Verification':
+            'SMS only by design — verifying a phone by email verifies nothing — so it needs '
+            'live Twilio credentials',
+        'Customer/Verify Phone Number':
+            'consumes the code Request Phone Verification would have sent',
+        'Store/List Network Stores':
+            'the contract key is a store, not a network — "Stores cannot have stores!"',
+    },
+}
+
 RUN_LATE = {
     'Fleetbase API': [
         'Orders/Update an Order',       # needs {{service_quote_id}} from Service Quotes/Query Service Quotes
@@ -106,6 +139,7 @@ def field(path, key, default=None):
 run_last = {p: i for i, p in enumerate(RUN_LAST.get(os.path.basename(root.rstrip('/')), []))}
 delete_first = {p: i for i, p in enumerate(DELETE_FIRST.get(os.path.basename(root.rstrip('/')), []))}
 run_late = {p: i for i, p in enumerate(RUN_LATE.get(os.path.basename(root.rstrip('/')), []))}
+excluded = EXCLUDED.get(os.path.basename(root.rstrip('/')), {})
 
 def line_value(path, key):
     """Read a scalar whose value may contain spaces, e.g. `name: A long title`.
@@ -143,6 +177,10 @@ for folder in os.listdir(root):
         rorder = int(field(p, 'order', 10**9))
         path = f'{folder}/{name}'
         seen.add(path)
+        if path in excluded:
+            # Reported every run so an exclusion cannot quietly become permanent.
+            print(f'::notice::excluded from the contract run — {path}: {excluded[path]}', file=sys.stderr)
+            continue
         if path in run_last:
             # Phase 3 sorts after the DELETEs: "pinned last" means last, and
             # explicit intent beats the heuristic. Nothing in Fleetbase API
@@ -175,3 +213,6 @@ for *_key, path in sorted(items):
 for path in run_last:
     if path not in seen:
         print(f'::warning::RUN_LAST entry not found in collection: {path}', file=sys.stderr)
+for path in excluded:
+    if path not in seen:
+        print(f'::warning::EXCLUDED entry not found in collection: {path}', file=sys.stderr)

--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -66,35 +66,21 @@ import os, re, sys
 # request that merely fails today — every entry states a structural reason the public API
 # cannot reach it. Each one is echoed on every run so it stays visible rather than rotting.
 EXCLUDED = {
-    'Fleetbase API': {
-        'Drivers/Switch Driver Organization':
-            'switches to {{organization_id}}, the org the driver is already in; needs a '
-            'driver with membership in a SECOND organization, which no public endpoint creates',
-        'Orders/Capture QR Code for Order':
-            'captureQrScan requires $code === $subject->uuid, and the public API never '
-            'exposes uuids (qr_code is $this->when($isInternal, ...))',
-        'Tracking Numbers/Decode Tracking Number QR':
-            'same uuid gate as Capture QR Code — from-qr matches on uuid, which the public '
-            'API does not expose',
-    },
     'Fleetbase Storefront API': {
         'Customer/Authenticate a Customer with Apple':
-            'needs a real Apple identity token; no fixture can produce a verifiable one',
+            'needs a real Apple identity token; Apple signs it, so no fixture can produce '
+            'a verifiable one',
         'Customer/Authenticate a Customer with Google':
-            'needs a real Google id token',
-        'Customer/Request Phone Verification':
-            'SMS only by design — verifying a phone by email verifies nothing — so it needs '
-            'live Twilio credentials',
-        'Customer/Verify Phone Number':
-            'consumes the code Request Phone Verification would have sent',
-        'Store/List Network Stores':
-            'the contract key is a store, not a network — "Stores cannot have stores!"',
+            'needs a real Google id token, signed by Google, for the same reason',
     },
 }
 
 RUN_LATE = {
     'Fleetbase API': [
         'Orders/Update an Order',       # needs {{service_quote_id}} from Service Quotes/Query Service Quotes
+        # {{qr_code}} is decoded from the PNG that Tracking Numbers/Create a Tracking
+        # Number returns, which runs in a later folder.
+        'Orders/Capture QR Code for Order',
     ],
     'Fleetbase Storefront API': [
         # The cart has to be populated before anything prices or checks out against it,


### PR DESCRIPTION
**Revised after review.** The first version excluded eight requests. Six of those were not structurally unreachable — they needed fixtures or a decode step, which is work, not a limit. Thanks for pushing back; the list is now two.

## Removed from the list, and covered instead

| request | how it is covered now |
| --- | --- |
| `Switch Driver Organization` | seeded second organization + `CompanyUser` membership (#603) |
| `List Network Stores` | seeded network and network key (#603) |
| `Capture QR Code for Order` | QR decoded from the PNG in an after-response script (fleetbase/postman#37) |
| `Decode Tracking Number QR` | same decoded value |
| `Request Phone Verification` | review-account bypass — the mechanism already exists and simply was not applied there |
| `Verify Phone Number` | same |

## What remains

Two requests needing a token **signed by a third party**:

- `Authenticate a Customer with Apple` — Apple signs the identity token
- `Authenticate a Customer with Google` — Google signs the id token

No fixture can produce a verifiable one; that is precisely what those endpoints check. If you would rather cover them with a stubbed verifier, say so and I will do that instead — it would mean the contract tests our verification wiring rather than the provider handshake, which is a real trade-off either way.

## Also here

`Capture QR Code for Order` moves to `RUN_LATE`: `{{qr_code}}` is decoded from the PNG that `Create a Tracking Number` returns, which lives in a later folder. Order is now 152 Create a Tracking Number → 153 Decode → 161 Capture.

Emitted counts: **189 for Fleetbase API — no exclusions at all** — and 58 of 60 for Storefront. core-api and ledger remain at 24 and 8 with none.

The guardrails from the first version stay: every exclusion prints a `::notice::` on each run, and a stale entry warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)