### PR TITLE
ci(api-contract): seed a network and a second organization

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -159,6 +159,9 @@ runs:
         STOREFRONT_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_STOREFRONT_KEY=store_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         INVOICE_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INVOICE_ID=[A-Za-z0-9_]+' | tail -1 | cut -d= -f2 || true)"
         GATEWAY_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_LEDGER_GATEWAY=[A-Za-z0-9_]+' | tail -1 | cut -d= -f2 || true)"
+        NETWORK_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_NETWORK_KEY=network_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        SECONDARY_ORG_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_SECONDARY_ORGANIZATION_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        MULTI_ORG_DRIVER_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_DRIVER_ID=driver_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -221,6 +224,18 @@ runs:
         else
           echo "::warning::No payment gateway seeded; the gateway-backed requests will report it as unavailable."
         fi
+        # Network-scoped endpoints need a network session, which a store key cannot give.
+        if [[ -n "$NETWORK_KEY" ]]; then
+          echo "::add-mask::$NETWORK_KEY"
+          echo "network_key=$NETWORK_KEY" >> "$GITHUB_OUTPUT"
+        fi
+        # Switch Driver Organization needs a driver that belongs to TWO organizations.
+        if [[ -n "$SECONDARY_ORG_ID" ]]; then
+          echo "secondary_organization_id=$SECONDARY_ORG_ID" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -n "$MULTI_ORG_DRIVER_ID" ]]; then
+          echo "multi_org_driver_id=$MULTI_ORG_DRIVER_ID" >> "$GITHUB_OUTPUT"
+        fi
         if [[ -n "$PLATFORM_TOKEN" ]]; then
           echo "::add-mask::$PLATFORM_TOKEN"
           echo "platform_token=$PLATFORM_TOKEN" >> "$GITHUB_OUTPUT"
@@ -267,6 +282,9 @@ runs:
         ORGANIZATION_ID: ${{ steps.key.outputs.organization_id }}
         INVOICE_PUBLIC_ID: ${{ steps.key.outputs.invoice_public_id }}
         GATEWAY_ID: ${{ steps.key.outputs.gateway_id }}
+        NETWORK_KEY: ${{ steps.key.outputs.network_key }}
+        SECONDARY_ORG_ID: ${{ steps.key.outputs.secondary_organization_id }}
+        MULTI_ORG_DRIVER_ID: ${{ steps.key.outputs.multi_org_driver_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
         NAMESPACE: ${{ inputs.namespace }}
@@ -346,6 +364,9 @@ runs:
           '  --env-var "proof_signature_base64=iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAbElEQVR42hXNQRUAUQhCUaMYhShGeVGIQhSizB+XXA7ODDtouIHBQ4YOM8suWm5h8ZKl+0CskDiBsIioHhx76LiDw0eO3oN/4FVf+J8h0PduzBqZ8x/bxNQPwgaFy192SGgelC0q13/CJaXlA8Z7WAFXOTbyAAAAAElFTkSuQmCC" \' \
           '  --env-var "invoice_public_id=${INVOICE_PUBLIC_ID}" \' \
           '  --env-var "gateway_id=${GATEWAY_ID}" \' \
+          '  --env-var "network_key=${NETWORK_KEY}" \' \
+          '  --env-var "secondary_organization_id=${SECONDARY_ORG_ID}" \' \
+          '  --env-var "multi_org_driver_id=${MULTI_ORG_DRIVER_ID}" \' \
           '  --env-var "payment_reference=ci-contract-payment-reference" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -274,8 +274,72 @@ try {
     $driverCode->code = $customerCode;
     $driverCode->save();
 
+    /* ============================================================
+     | SECOND ORGANIZATION (Switch Driver Organization)
+     * ============================================================ */
+
+    // switchOrganization rejects a switch to the org the driver is already in, and then
+    // requires a CompanyUser row proving membership of the target. Neither can be created
+    // through the public API, so the seeded driver is given a second organization here:
+    // a company, a CompanyUser row, and a driver profile in it.
+    //
+    // The collection's other driver requests use {{driver_id}} from Create a Driver, whose
+    // user belongs to one company only — hence a separate {{multi_org_driver_id}} for the
+    // one request that needs two.
+    $secondCompany = \Fleetbase\Models\Company::firstOrCreate(['name' => 'CI Contract Org (Secondary)']);
+    if (empty($secondCompany->owner_uuid)) {
+        $secondCompany->setOwner($user, true);
+        $secondCompany->save();
+    }
+
+    \Fleetbase\Models\CompanyUser::firstOrCreate([
+        'company_uuid' => $secondCompany->uuid,
+        'user_uuid'    => $driverUser->uuid,
+    ], ['status' => 'active']);
+
+    if (class_exists(\Fleetbase\FleetOps\Models\Driver::class)) {
+        \Fleetbase\FleetOps\Models\Driver::firstOrCreate(
+            ['user_uuid' => $driverUser->uuid, 'company_uuid' => $secondCompany->uuid],
+            ['status' => 'active', 'online' => 0]
+        );
+    }
+
+    echo 'SEEDED_SECONDARY_ORGANIZATION_ID=' . $secondCompany->public_id . PHP_EOL;
+
     echo 'SEEDED_DRIVER_IDENTITY=' . $driverIdentity . PHP_EOL;
     echo 'SEEDED_DRIVER_PHONE=' . $driverPhone . PHP_EOL;
+
+    /* ============================================================
+     | NETWORK (Storefront network-scoped endpoints)
+     * ============================================================ */
+
+    // List Network Stores answered "Stores cannot have stores!" because the contract
+    // authenticates with a STORE key, and the network endpoints require a network session.
+    // Network::boot() generates `key = 'network_' . md5(...)` on insert exactly like Store,
+    // so a seeded network yields a usable key; the collection's network requests send it
+    // instead of the store key.
+    if (isset($store) && class_exists(\Fleetbase\Storefront\Models\Network::class)) {
+        $network = \Fleetbase\Storefront\Models\Network::withoutGlobalScopes()
+            ->where(['company_uuid' => $company->uuid, 'name' => 'CI Contract Network'])
+            ->first();
+
+        if (!$network) {
+            $network = \Fleetbase\Storefront\Models\Network::create([
+                'company_uuid'    => $company->uuid,
+                'created_by_uuid' => $user->uuid,
+                'name'            => 'CI Contract Network',
+                'description'     => 'Seeded by the API contract run.',
+                'currency'        => 'USD',
+                'online'          => 1,
+            ]);
+        }
+
+        // Without a member store the listing is empty and proves nothing.
+        $network->addStore($store);
+
+        echo 'MINTED_NETWORK_KEY=' . $network->fresh()->key . PHP_EOL;
+        echo 'MINTED_NETWORK_ID=' . $network->public_id . PHP_EOL;
+    }
 
     /* ============================================================
      | STORE LOCATION (Storefront)


### PR DESCRIPTION
Both of these were flagged as uncoverable in #602. **They are not** — they just need fixtures the public API cannot create, which is exactly what the seed is for. Thanks for pushing back on them.

## Network — `List Network Stores`

The contract authenticates with a **store** key, and the network endpoints require a network session, hence *"Stores cannot have stores!"*.

`Network::boot()` generates `key = 'network_' . md5(...)` on insert exactly like `Store`, so a seeded network yields a usable key — injected as `{{network_key}}` and masked like the store key and platform token. The seeded store is added as a member, because an empty listing would prove nothing.

## Second organization — `Switch Driver Organization`

`switchOrganization` rejects a switch to the org the driver is already in, and then requires a `CompanyUser` row proving membership of the target. Neither can be created through the public API.

The seeded driver now has a second company, a `CompanyUser` row and a driver profile in it.

One wrinkle worth knowing: `{{driver_id}}` comes from `Create a Driver`, whose user belongs to a single company, so it can't be the one that switches. The multi-org driver is injected separately as `{{multi_org_driver_id}}`, with `{{secondary_organization_id}}` as the target. A companion change in fleetbase/postman points the request at them — and states the precondition in the description, which is arguably better documentation than the current example, since "you need a driver in two orgs" is invisible today.

## Effect on #602

Two exclusions come off that list. I'm revising it down — see the discussion there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)