### PR TITLE
ci(api-contract): configure the storefront review account

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -216,6 +216,12 @@ jobs:
               echo "$1=$2" >> api/.env
             fi
           }
+          # The storefront review-account bypass, pointed at the seeded customer's phone.
+          # This is the same mechanism App Store review uses, and it is inert without BOTH
+          # values — the code alone is not accepted for an identity that is not listed.
+          # It lets phone verification be exercised without a live SMS provider.
+          set_env STOREFRONT_BYPASS_VERIFICATION_CODE 000000
+          set_env STOREFRONT_REVIEW_ACCOUNTS '+15555550123'
           set_env MAIL_MAILER log
           set_env MAIL_FROM_ADDRESS ci-contract@fleetbase.local
           echo "Mail transport: log (from ci-contract@fleetbase.local)"


### PR DESCRIPTION
Completes the phone-verification half of the #602 review feedback.

The review-account bypass is **inert unless both values are set** — that is deliberate in its design, since the code alone must never be accepted for an arbitrary identity. The contract stack now sets them for the seeded customer's phone, so `Request Phone Verification` and `Verify Phone Number` are exercised without a live SMS provider.

This is the same mechanism App Store review uses, scoped to a single seeded identity in a throwaway stack.

Pairs with fleetbase/storefront@bc3a773, which applies the bypass to both ends:

- `requestPhoneVerification` — a review account needs no message delivered, so the send is skipped and the response reports `method=bypass`
- `verifyPhoneNumber` — accepts the configured code for a listed account. The bypass leaves no code row to read the phone back from, so it comes from the request, which is what the caller is asking to verify

A code that is *not* the bypass is still rejected for the same account; the test asserts that alongside the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)