### PR TITLE
ci(api-contract): run account closure last — it deletes the customer

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -104,6 +104,15 @@ DELETE_FIRST = {
 }
 
 RUN_LAST = {
+    # Account closure DELETES the customer's user account. It is a POST, so the DELETE
+    # heuristic does not catch it, and once it succeeded every later authenticated request
+    # failed with "Not authorized" — the customer was gone. It only started succeeding once
+    # its verification code was seeded correctly, which is how a fixture fix turned into a
+    # 7-request regression.
+    'Fleetbase Storefront API': [
+        'Customer/Start Account Closure',
+        'Customer/Confirm Account Closure',
+    ],
     'Fleetbase API': [
         'Customers/Request Customer Login SMS',     # needs User.phone restored by Update Me
         'Customers/Logout Customer',                # revokes the current token


### PR DESCRIPTION
`Confirm Account Closure` **deletes the customer's user account**. It is a `POST`, so the DELETE heuristic never deferred it, and it ran at position 22 of 58. Every authenticated request after it then failed with *"Not authorized"* or *"Customer is not authenticated"* — the customer was gone.

Seven requests regressed this way:

`Request Phone Verification`, `Verify Phone Number`, `List a customer saved places`, `List a customer orders`, `Update Contact Customer Alias`, `Complete Order Pickup`, `Register customer device`

**Storefront went 42 → 35.**

## Why it surfaced now

The request had always been there, but it always *failed* — *"Invalid verification code provided!"* — so the account survived. #600 seeded its code under the identity `confirmAccountClosure` actually looks up (`$user->phone ?? $user->email`), and it started succeeding.

So a fixture fix turned a permanently-broken request into a destructive one. Worth remembering: in a suite where a request has never passed, making it pass is a behaviour change, not just a number going up.

## Fix

Both closure requests are pinned to `RUN_LAST` — exactly what that list exists for; the FleetOps customer logout and password reset are there for the same reason. They now run at 57 and 58, after the deletes that also need the customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)