### PR TITLE
ci(api-contract): exclude the QR pair — the CLI cannot load npm packages

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -66,6 +66,22 @@ import os, re, sys
 # request that merely fails today — every entry states a structural reason the public API
 # cannot reach it. Each one is echoed on every run so it stays visible rather than rotting.
 EXCLUDED = {
+    'Fleetbase API': {
+        # NOT a structural limit, and not a collection defect: the decode script on
+        # Create a Tracking Number is correct and works in the Postman app. The CLI
+        # cannot resolve npm packages for a LOCAL collection directory — Postman's
+        # package library is a cloud feature — so the run logs
+        #   Cannot find package 'npm:jsqr@1.4.0'
+        # and {{qr_code}} is never set. Verified against CLI 2.336.0; there is no flag
+        # for it in `postman --help` or `postman collection run --help`.
+        #
+        # Remove both the day the CLI resolves packages, or the run moves to a cloud
+        # collection. The script stays either way — it is correct documentation.
+        'Tracking Numbers/Decode Tracking Number QR':
+            'needs {{qr_code}}, decoded from the QR PNG by an npm package the CLI cannot load',
+        'Orders/Capture QR Code for Order':
+            'same decoded value',
+    },
     'Fleetbase Storefront API': {
         'Customer/Authenticate a Customer with Apple':
             'needs a real Apple identity token; Apple signs it, so no fixture can produce '


### PR DESCRIPTION
The `jsqr` approach works — **in the Postman app**. It does not work in the CLI, and the run tells us exactly why:

```
QR decode unavailable: Cannot find package 'npm:jsqr@1.4.0'
```

Postman's package library is a **cloud** feature: `pm.require('npm:…')` resolves server-side for a cloud collection. The contract run executes a **local collection directory**, so packages are never fetched. Verified against CLI **2.336.0** (the version CI installs); there is no flag for it in `postman --help` or `postman collection run --help`.

The guard in fleetbase/postman#37 did its job — it logged the reason and the run continued rather than the collection dying on an unhandled script error.

## What this exclusion is, and is not

It is **not** the structural claim I made in the first version of #602, and it is **not** a defect in the collection. The script is correct and gives a human running the collection in Postman a working decode. The comment in the source says exactly this, and says to remove both entries the day the CLI resolves packages or the run moves to a cloud collection.

The script stays regardless — it documents how a client turns a scanned code into a request, which is the thing worth showing.

## Counts

Fleetbase API 189 → 187 emitted, Storefront 60 → 58. core-api and ledger remain at 24 and 8 with no exclusions.

If you would rather run the collections from the cloud so packages resolve, say so — that changes how the action invokes the CLI and would let both requests back in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)