### PR TITLE
ci(api-contract): fix the food truck vehicle, which aborted the whole seed

### DIFF
--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -331,6 +331,10 @@ try {
                 'model'        => 'Food Truck',
                 'year'         => 2026,
                 'status'       => 'active',
+                // Both are NOT NULL without a default. `location` is the spatial column
+                // that already broke sensor and fuel report creation; `online` is the same
+                // trap one column over, and it aborted the whole seed.
+                'online'       => 0,
                 'location'     => new \Fleetbase\LaravelMysqlSpatial\Types\Point(1.3521, 103.8198),
             ]);
         }


### PR DESCRIPTION
`vehicles.online` is NOT NULL without a default, so creating the food truck's vehicle threw and **the seed died at that point**:

```
MINT_ERROR: SQLSTATE[HY000] 1364 Field 'online' doesn't have a default value
```

Everything after it never ran — the network, store location, service rate, Stripe gateway and ledger invoice fixtures were all silently absent, and the requests depending on them failed for reasons that looked unrelated to the real cause.

This is the same trap as the spatial columns, one column over: `location` already broke sensor creation (fleetbase/fleetops@119bc887) and fuel report creation (fleetbase/fleetops@8c099a52). That is now **four** NOT NULL-without-default columns hit in this effort, which is worth a schema sweep in its own right.

## Two follow-ups this exposes

1. **The seed is all-or-nothing.** One failing optional fixture aborts every fixture after it. Each block should be isolated so a failure degrades one fixture and says so, rather than taking the rest down. I have not done that here because it touches every block and this fix is urgent.
2. **The mint prints its output only on failure**, so a partial seed is invisible — the job goes green on the seed step and the damage shows up as unrelated request failures much later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)