### PR TITLE
ci(api-contract): fail loudly when the seed aborts partway

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -153,6 +153,20 @@ runs:
           -e "CI_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}" \
           -e "CI_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}" \
           application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
+        # Always surface what the seed produced, not only when a step later fails.
+        #
+        # The mint runs one PHP snippet inside a single try, so the FIRST fixture that
+        # throws aborts every fixture after it — and the step still exits 0 as long as the
+        # API key came out. A vehicle column with no default did exactly that: the network,
+        # store location, service rate, gateway and invoice fixtures were all silently
+        # absent, and the requests needing them failed much later for reasons that looked
+        # unrelated. MINT_ERROR is echoed by the snippet's catch; make it loud.
+        printf '%s\n' "$OUT" | grep -E '^(MINTED_|SEEDED_|MINT_ERROR)' || true
+        if printf '%s\n' "$OUT" | grep -q 'MINT_ERROR'; then
+          echo "::error::The seed aborted partway. Fixtures after the failure were NOT created:"
+          printf '%s\n' "$OUT" | grep -A 2 'MINT_ERROR'
+          exit 1
+        fi
         KEY="$(printf '%s\n' "$OUT" | grep -oE 'flb_(live|test)_[A-Za-z0-9_-]+' | tail -1 || true)"
         PLATFORM_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'flb_platform_[A-Za-z0-9]+' | tail -1 || true)"
         ORGANIZATION_ID="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_COMPANY_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"


### PR DESCRIPTION
The mint runs one PHP snippet inside a single `try`, so the **first** fixture that throws aborts every fixture after it — and the step still exited 0, because the API key had already been produced and that is all it checked.

That is exactly what #611 fixed the cause of. A vehicle column with no default killed the seed, so the network, store location, service rate, Stripe gateway and ledger invoice fixtures were never created. The run then failed a dozen requests for reasons that looked like fixture bugs — and I read them that way for a full cycle before spotting it.

## Two changes

- The seed's `MINTED_` / `SEEDED_` lines are printed on **every** run, so what actually got created is visible rather than inferred from downstream failures.
- `MINT_ERROR` is now fatal, with the exception and its location.

## Verification

Replayed the real failure text from the run that prompted this. The guard prints the fixtures that *were* created, reports the error with its file and line, and exits 1:

```
MINTED_API_KEY=flb_live_abc
MINTED_COMPANY_ID=company_x
SEEDED_DRIVER_ID=driver_y
::error::The seed aborted partway. Fixtures after the failure were NOT created:
MINT_ERROR: Illuminate\Database\QueryException: Field 'online' has no default
```

## What this does not do

It does **not** make the seed resilient — one failure still aborts the rest. It makes that state impossible to miss. Isolating each fixture block so a single one can fail on its own is a separate change, and a bigger one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)