### PR TITLE
ci(api-contract): tune the activity cycle to what the flow consumes

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -85,8 +85,14 @@ EXCLUDED = {
 # complete), so `times` is well above the stop count rather than equal to it. Six cycles
 # applied cleanly and still left "Not all waypoints completed for order."
 #
-# A surplus cycle is harmless: once the flow is exhausted updateActivity answers
-# "Order is already completed." and the assertions have already had what they need.
+# A surplus cycle is NOT harmless, which an earlier version of this comment got wrong:
+# once the flow is exhausted updateActivity answers "Order is already completed." with a
+# 400, and each extra pass is a counted failure. 16 passes completed the order and then
+# failed four times; 12 is what the flow actually consumes.
+#
+# So this number is tied to the order config's activity count and the collection's
+# waypoint count. If either changes, the tail of the cycle starts failing — the fix is to
+# retune this, not to treat it as an API problem.
 #
 # `then` runs after the cycle, which is the only way Complete an Order can see every
 # waypoint COMPLETED.
@@ -96,7 +102,7 @@ CYCLES = {
             'Orders/Get Order Next Activity',
             'Orders/Update Order Activity',
         ],
-        'times': 16,
+        'times': 12,
         'then': ['Orders/Complete an Order'],
     },
 }


### PR DESCRIPTION
**"A surplus cycle is harmless" was wrong**, and I asserted it in both #607 and #609 without checking.

Once the flow is exhausted `updateActivity` answers *"Order is already completed."* with a **400**, so every extra pass is a counted failure. 16 passes completed the order and then failed four times — visible as four identical `Update Order Activity` failures in the last run.

**12 is what the flow actually consumes.** `Complete an Order` now passes, which is what the cycle was for.

The number is tied to the order config's activity count and the collection's waypoint count, and the comment now says so: if either changes, the tail of the cycle starts failing, and the fix is to retune it rather than read it as an API problem.

fleetops was **212/219** on the last run; this should take it to 216/215-equivalent with only the three known items left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)