### PR TITLE
fix(ci): prevent script injection via PR branch name in cloud workflow

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -1,21 +1,64 @@
-name: "Close Invalid PRs"
+name: "Enforce Cloud Promotion PRs"
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
     branches:
       - cloud
+      - cloud-qa
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  close_pr:
+  enforce_promotion_path:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Close invalid PRs
+      - name: Validate promotion path
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [[ "$PR_HEAD_REF" != "main" ]] && [[ "$PR_HEAD_REF" != "dev-cloud" ]]; then
-            echo "This PR is from '$PR_HEAD_REF', but only PRs from 'main' or 'dev-cloud' are allowed. Closing PR."
-            gh pr close "$PR_NUMBER" --repo "$REPO"
+          set -euo pipefail
+
+          allowed=false
+
+          if [[ "$PR_HEAD_REPOSITORY" == "$REPOSITORY" ]]; then
+            case "$PR_BASE_REF" in
+              cloud-qa)
+                if [[ "$PR_HEAD_REF" == "main" ]]; then
+                  allowed=true
+                fi
+                ;;
+              cloud)
+                if [[ "$PR_HEAD_REF" == "cloud-qa" || "$PR_HEAD_REF" == "main" ]]; then
+                  allowed=true
+                fi
+                ;;
+            esac
           fi
+
+          if [[ "$allowed" == "true" ]]; then
+            echo "Allowed promotion: $PR_HEAD_REPOSITORY:$PR_HEAD_REF -> $PR_BASE_REF"
+            exit 0
+          fi
+
+          case "$PR_BASE_REF" in
+            cloud-qa)
+              message="This pull request was closed because cloud-qa only accepts promotions from the main branch in the fleetbase/fleetbase repository."
+              ;;
+            cloud)
+              message="This pull request was closed because cloud only accepts promotions from the cloud-qa branch, or emergency promotions from main, in the fleetbase/fleetbase repository."
+              ;;
+            *)
+              message="This pull request was closed because it does not follow the Fleetbase cloud promotion path."
+              ;;
+          esac
+
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"
+          gh pr close "$PR_NUMBER" --repo "$REPOSITORY"

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -9,10 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close invalid PRs
-        run: |
-          if [[ "${{ github.event.pull_request.head.ref }}" != "main" ]] && [[ "${{ github.event.pull_request.head.ref }}" != "dev-cloud" ]]; then
-            echo "This PR is from '${{ github.event.pull_request.head.ref }}', but only PRs from 'main' or 'dev-cloud' are allowed. Closing PR."
-            gh pr close ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
-          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$PR_HEAD_REF" != "main" ]] && [[ "$PR_HEAD_REF" != "dev-cloud" ]]; then
+            echo "This PR is from '$PR_HEAD_REF', but only PRs from 'main' or 'dev-cloud' are allowed. Closing PR."
+            gh pr close "$PR_NUMBER" --repo "$REPO"
+          fi


### PR DESCRIPTION
## Summary

`.github/workflows/cloud.yml` interpolates the untrusted value
`github.event.pull_request.head.ref` directly into a shell `run:` block. A pull
request author controls the source branch name, so shell metacharacters in a
valid Git branch name can be interpreted as commands by the runner. This is a
GitHub Actions script-injection issue (CWE-94).

This PR also updates the obsolete `dev-cloud` rule and enforces Fleetbase's
current cloud promotion path:

- normal pull requests target `main`
- `fleetbase/fleetbase:main` promotes to `cloud-qa`
- `fleetbase/fleetbase:cloud-qa`, or emergency `main`, promotes to `cloud`

## Vulnerability

GitHub evaluates `${{ }}` expressions before writing and executing a step's
temporary shell script. Branch names can contain shell-significant characters.
For example, this harmless value is a valid Git branch name:

```text
$(printf${IFS}INJECTED)
```

When interpolated directly into the existing `run:` block, its command
substitution executes on the runner. Passing event values through `env:` and
using quoted shell variables ensures the values are handled as data instead of
shell source code.

For external fork pull requests using the original `pull_request` trigger,
GitHub normally provides a read-only `GITHUB_TOKEN` and withholds repository
secrets. That limits the current impact, but does not prevent arbitrary command
execution, runner-compute or network abuse, workflow-token disclosure, or log
tampering.

## Fix and promotion enforcement

- Pass the base branch, head branch, head repository, pull request number, and
  repository through environment variables and quote every shell expansion.
- Use `pull_request_target` for pull requests targeting `cloud` or `cloud-qa`,
  with only `contents: read` and `pull-requests: write` permissions.
- Never check out or execute pull-request code in the privileged workflow.
- Validate both the source repository and source branch, so a fork cannot
  bypass the rule by naming its branch `main` or `cloud-qa`.
- Comment with the permitted promotion path and close invalid pull requests.

## Validation

- `actionlint` passes for the workflow.
- Allowed promotion cases pass locally.
- Fork and disallowed source cases are commented on and closed.
- Valid branch names using command substitution or backticks are treated only
  as data and do not execute.
- The workflow contains no checkout step, pull-request-head execution, or
  direct untrusted expression inside the shell script.
