### PR TITLE
ci(api-contract): give the cart lifecycle and the checkout their own carts

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -115,11 +115,29 @@ RUN_LATE = {
         'Orders/Capture QR Code for Order',
     ],
     'Fleetbase Storefront API': [
-        # The cart has to be populated before anything prices or checks out against it,
-        # and emptied only once those are done. Deferring just the three Cart requests
-        # left Checkout running against an empty cart — "The selected cart is invalid."
+        # TWO carts, deliberately.
+        #
+        # The cart lifecycle (add, update, remove) and the checkout chain want opposite
+        # things from the same {{cart_id}}: the lifecycle ends with the cart emptied, and
+        # checkout needs it populated. Sharing one cart used to work only because the
+        # mutating cart actions ignored Cart::retrieve()'s $excludeCheckedout and would
+        # happily edit a cart that had already produced an order. Once that was fixed,
+        # running Remove last answered "Invalid cart item provided to cart!" — the cart
+        # was checked out, so the API handed back a fresh empty one.
+        #
+        # GET /carts takes no identifier, so Retrieve or Create Cart ALWAYS creates a new
+        # cart and re-points {{cart_id}} at it. Running it twice is what gives each half
+        # its own cart, using only requests the collection already documents.
+
+        # Cart A — the lifecycle, start to finish.
+        'Cart/Retrieve or Create Cart',
         'Cart/Add Item to Cart',        # needs {{product_id}} from Products/Create Product
         'Cart/Update item in Cart',     # needs the line item Add Item to Cart creates
+        'Cart/Remove item from cart',   # leaves cart A empty, which is the point
+
+        # Cart B — priced, checked out, and turned into an order.
+        'Cart/Retrieve or Create Cart',
+        'Cart/Add Item to Cart',
         'Delivery Service Quote/Retrieve a Delivery Service Quote ❗',  # prices the cart
         'Checkout/Before ❗',                    # needs the cart AND {{service_quote_id}}
         'Checkout/Capture checkout as order',    # needs {{checkout_token}} from Before
@@ -129,7 +147,6 @@ RUN_LATE = {
         # creates a storefront order.
         'Orders/Complete Order Pickup',
         'Orders/Get Order Receipt',
-        'Cart/Remove item from cart',   # LAST: it empties what the above depend on
     ],
 }
 
@@ -169,7 +186,13 @@ def field(path, key, default=None):
 # Pinned order for this collection, as {path: index}. Unknown collection => {}.
 run_last = {p: i for i, p in enumerate(RUN_LAST.get(os.path.basename(root.rstrip('/')), []))}
 delete_first = {p: i for i, p in enumerate(DELETE_FIRST.get(os.path.basename(root.rstrip('/')), []))}
-run_late = {p: i for i, p in enumerate(RUN_LATE.get(os.path.basename(root.rstrip('/')), []))}
+# RUN_LATE is emitted verbatim rather than folded into the sort, so a request may appear
+# in it more than once. The CLI honours repeated -i flags, which is how the Storefront
+# collection gets a second cart out of Retrieve or Create Cart without inventing a
+# request. A path listed here is removed from the ordinary phase entirely — if it also
+# needs to run early, list it early here.
+run_late_seq = list(RUN_LATE.get(os.path.basename(root.rstrip('/')), []))
+run_late     = set(run_late_seq)
 cycles = CYCLES.get(os.path.basename(root.rstrip('/')), {})
 cycled = set(cycles.get('sequence', [])) | set(cycles.get('then', []))
 excluded = EXCLUDED.get(os.path.basename(root.rstrip('/')), {})
@@ -213,6 +236,10 @@ for folder in os.listdir(root):
         if path in cycled:
             # Emitted by the cycle block after the ordinary phase, in dependency order.
             continue
+        if path in run_late:
+            # Emitted verbatim from run_late_seq after the ordinary phase, so that a
+            # request listed twice actually runs twice.
+            continue
         if path in excluded:
             # Reported every run so an exclusion cannot quietly become permanent.
             print(f'::notice::excluded from the contract run — {path}: {excluded[path]}', file=sys.stderr)
@@ -230,9 +257,6 @@ for folder in os.listdir(root):
             # forder is always non-negative.
             phase, primary, secondary = 2, delete_first[path] - len(delete_first), 0
             sort_folder = ''
-        elif path in run_late:
-            phase, primary, secondary = 1, run_late[path], 0
-            sort_folder = ''
         else:
             phase, primary, secondary = (2 if method == 'DELETE' else 0), forder, rorder
             sort_folder = folder
@@ -246,6 +270,9 @@ ordered = sorted(items)
 for key in ordered:
     if key[0] <= 1:
         print(key[-1])
+
+for path in run_late_seq:
+    print(path)
 
 for _ in range(cycles.get('times', 0)):
     for path in cycles['sequence']:
@@ -269,6 +296,12 @@ for path in cycled:
 for path in run_last:
     if path not in seen:
         print(f'::warning::RUN_LAST entry not found in collection: {path}', file=sys.stderr)
+for path in run_late:
+    if path not in seen:
+        # RUN_LATE is the only list whose entries are printed without being matched against
+        # a file first, so a typo here would send the CLI an -i it cannot resolve — which
+        # aborts the whole run with 0 requests executed.
+        print(f'::warning::RUN_LATE entry not found in collection: {path}', file=sys.stderr)
 for path in excluded:
     if path not in seen:
         print(f'::warning::EXCLUDED entry not found in collection: {path}', file=sys.stderr)


### PR DESCRIPTION
Making checked-out carts immutable in storefront ([storefront@d93ac9a](https://github.com/fleetbase/storefront/commit/d93ac9a) — `Cart::retrieve()`'s `$excludeCheckedout` was being fed a flag the caller had named `$create`) exposed an ordering problem this script had been papering over.

`Cart/Remove item from cart` was pinned **last**, after `Checkout/Capture checkout as order` — so it addressed a cart that had already produced an order. That only ever worked because the mutating cart actions ignored `$excludeCheckedout`. Once they stopped, the request answered *"Invalid cart item provided to cart!"*: the API no longer finds a checked-out cart, so it hands back a fresh empty one.

## Two carts

The two halves want opposite things from the same `{{cart_id}}` — the lifecycle ends with the cart emptied, checkout needs it populated.

`GET /carts` takes no identifier, so `Retrieve or Create Cart` **always** creates a new cart and re-points `{{cart_id}}` at it. Listing it twice is what separates the two halves, using only requests the collection already documents — no new request, and no change to the published structure.

```
cart A:  Retrieve or Create -> Add -> Update -> Remove
cart B:  Retrieve or Create -> Add -> quote -> before -> capture -> status ->
         payment intent -> pickup -> receipt
```

## The mechanism change

`RUN_LATE` is now emitted verbatim instead of being folded into the sort, so an entry may repeat. The CLI honours repeated `-i` flags — the same property `CYCLES` already relies on.

One consequence worth knowing: a path in `RUN_LATE` is dropped from the ordinary phase entirely, so anything that also needs to run early has to be listed early. `Retrieve or Create Cart` is, at the head of cart A.

`RUN_LATE` entries are now warned about when they do not match a request, like `RUN_LAST` and `EXCLUDED` already were. It is the one list printed without being matched to a file first, so a typo would send the CLI an `-i` it cannot resolve and abort the run with 0 requests executed.

## Verification

Emitted order is **byte-identical** for Fleetbase API, Core API, Ledger API and the Integrated Vendor Flow — diffed against the current `main` version of the script. Only Storefront changes, and only in the intended way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)