### PR TITLE
ci(api-contract): run the QPay callbacks after the checkout that creates their id

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -147,6 +147,18 @@ RUN_LATE = {
         # creates a storefront order.
         'Orders/Complete Order Pickup',
         'Orders/Get Order Receipt',
+
+        # Both QPay callbacks address {{checkout_id}}, which only Before sets — in the
+        # Checkout folder they sort ahead of it and were sent the literal string
+        # "{{checkout_id}}", answering CHECKOUT_SESSION_NOT_FOUND every run.
+        #
+        # What they cover, precisely: capture-qpay short-circuits to a synthesised result
+        # when the checkout's gateway is in sandbox and `test` is success|error — it checks
+        # the sandbox flag, not the gateway type, and the seeded storefront gateway is
+        # sandbox. So this exercises the documented test-scenario branch, NOT the real
+        # invoice-check path, which needs live QPay credentials and cannot run here.
+        'Checkout/Capture QPay Callback',
+        'Checkout/Capture QPay Callback via GET',
     ],
 }
 


### PR DESCRIPTION
Both QPay callbacks address `{{checkout_id}}`, and `Checkout/Before` is the only request that sets it. In folder order they sort **ahead** of `Before`, so they were sent the literal string `"{{checkout_id}}"` and answered `CHECKOUT_SESSION_NOT_FOUND` on every run — a failure manufactured entirely by ordering.

Moving them to the tail of `RUN_LATE` puts them after `Before`, `Capture checkout as order` and `Get Checkout Status`, so they address a real checkout.

## What this actually covers

Worth being precise, so the coverage is not overstated.

`captureQPayCallback` short-circuits to a synthesised result when the checkout's gateway is in sandbox and `test` is `success|error`:

```php
if ($gateway->sandbox && in_array($testScenario, ['success', 'error'], true)) {
    $data['payment'] = QPay::createTestPaymentDataFromCheckout($checkout);
    ...
}
```

It checks the sandbox **flag**, not the gateway type, and the seeded storefront gateway is sandbox — so this exercises the **documented test-scenario branch** and nothing more. `createTestPaymentDataFromCheckout` builds the payload locally, so no network call is involved.

The real invoice-check path (`$qpay->paymentCheck($invoiceId)`) needs live QPay credentials and cannot run in CI. That stays uncovered, and the comment in the file says so rather than letting a green run imply otherwise.

## Verification

Emitted order diffed against the current `main` version of the script across all five collections: **byte-identical for Fleetbase API, Core API, Ledger API and the Integrated Vendor Flow**. Only the two Storefront entries move, from positions 37–38 to 55–56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)