### PR TITLE
ci(postman): stop the wire probe from failing the job

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -457,6 +457,14 @@ runs:
       if: steps.pmauth.outputs.available == 'true'
       shell: bash
       run: |
+        # set +e, not just -uo pipefail. GitHub runs composite steps under
+        # `bash -e -o pipefail`, and -uo does NOT clear the -e it inherits. That is
+        # not academic: `wait` on a process this step itself SIGTERMs returns 143,
+        # -e aborted the step there, and because a failed step skips the ones after
+        # it, the whole "Run Postman collections" step was skipped — the diagnostic
+        # took out the thing it was meant to diagnose. A diagnostic must never be
+        # able to fail the job, hence the explicit `exit 0` at the end too.
+        set +e
         set -uo pipefail
         POSTMAN_DIR="${GITHUB_WORKSPACE:-$PWD}/.postman"
         ECHO="${RUNNER_TEMP:-/tmp}/wire-echo.py"
@@ -483,7 +491,7 @@ runs:
         for i in $(seq 1 20); do
           # Distinct path so the readiness ping is filterable out of the wire log.
           curl -fsS --max-time 1 http://127.0.0.1:8099/__ready >/dev/null 2>&1 && break
-          [[ $i -eq 20 ]] && { echo "::warning::wire echo server never came up; skipping"; kill $echo_pid 2>/dev/null; exit 0; }
+          [[ $i -eq 20 ]] && { echo "::warning::wire echo server never came up; skipping"; kill "$echo_pid" 2>/dev/null; exit 0; }
           sleep 0.5
         done
 
@@ -506,10 +514,13 @@ runs:
         ) || true
 
         sleep 1
-        { kill $echo_pid; wait $echo_pid; } 2>/dev/null
+        # Every one of these is a plausible non-zero: kill races the exit, wait
+        # reports the signal as 143, and grep returns 1 when the log is empty.
+        kill "$echo_pid" 2>/dev/null || true
+        wait "$echo_pid" 2>/dev/null || true
         echo "Postman CLI: $(postman --version 2>&1 | head -1)"
         echo "--- what the two failing requests actually put on the wire ---"
-        grep -v "__ready" "$WIRE"
+        grep -v "__ready" "$WIRE" || echo "(nothing reached the echo server)"
         if grep -q 'SENTINEL_COLLECTION_AUTH' "$WIRE"; then
           echo "=> The COLLECTION-level bearer overrode the request-level Authorization header."
         elif grep -q 'SENTINEL_REQUEST_HEADER' "$WIRE"; then
@@ -517,6 +528,10 @@ runs:
         else
           echo "=> Neither sentinel arrived — the requests did not execute. Check for 'items were not found'."
         fi
+
+        # Belt and braces: a composite step cannot use continue-on-error, so the only
+        # way to guarantee this never blocks the collection run is to exit clean.
+        exit 0
 
     - name: Run Postman collections
       if: steps.pmauth.outputs.available == 'true'


### PR DESCRIPTION
Fixes my bug in #624. That probe aborted with **exit 143** and, because a failed step skips the steps after it, took **`Run Postman collections` with it** — on both [fleetops attempt 6](https://github.com/fleetbase/fleetops/actions/runs/32004602386) and [storefront attempt 6](https://github.com/fleetbase/storefront/actions/runs/32009383304). The diagnostic killed the thing it was meant to diagnose. Neither run produced wire data or contract results.

## Cause

GitHub runs composite steps under `bash -e -o pipefail`. The step opened with `set -uo pipefail`, which does **not** clear the inherited `-e`. `wait` on the echo server the step itself SIGTERMs returns 143, `-e` aborted right there, and every `echo` in the step came *after* that line — which is why the step printed nothing at all, not even the CLI version.

My local check missed it because it ran the script under a plain `bash`, with no `-e`.

## Fix

Verified under `bash --noprofile --norc -e -o pipefail` — the exact invocation in the runner log — on both paths:

| path | output | exit |
| --- | --- | --- |
| collections present | wire lines + verdict | **0** |
| `.postman` missing | `(nothing reached the echo server)` | **0** |

Three guards, any one of which would have sufficed, kept together because this step must never block the run again:

- explicit `set +e`
- `|| true` on `kill` and `wait`, and a fallback on the `grep`, which returns 1 when the wire log is empty
- a final `exit 0` — composite steps cannot use `continue-on-error`, so this is the only hard guarantee

No change to what the probe measures. Re-running after this merges should give both the wire verdict and a normal contract result in the same run.