### PR TITLE
fix(custom-fields): store a signature as a file value type

### DIFF
--- a/console/app/models/custom-field.js
+++ b/console/app/models/custom-field.js
@@ -32,7 +32,7 @@ export default class CustomFieldModel extends Model {
 
     /** @computed */
     @computed('type') get valueType() {
-        if (this.type === 'file-upload') return 'file';
+        if (this.type === 'file-upload' || this.type === 'signature-pad') return 'file';
         if (this.type === 'date-time-input') return 'date';
         if (this.type === 'model-select') return 'model';
 

--- a/console/tests/unit/models/custom-field-test.js
+++ b/console/tests/unit/models/custom-field-test.js
@@ -21,6 +21,7 @@ module('Unit | Model | custom-field | valueType', function (hooks) {
         const field = (type) => store.createRecord('custom-field', { type }).valueType;
 
         assert.strictEqual(field('file-upload'), 'file');
+        assert.strictEqual(field('signature-pad'), 'file', 'a signature is uploaded and stored as a file');
         assert.strictEqual(field('date-time-input'), 'date');
         assert.strictEqual(field('model-select'), 'model');
         assert.strictEqual(field('text-input'), 'text', 'anything else stores plain text');


### PR DESCRIPTION
`signature-pad` custom fields upload their PNG through the Files API and store the same `file:<uuid>` sentinel that `file-upload` does, so `valueType` should report `'file'` rather than falling through to `'text'`.

```diff
-        if (this.type === 'file-upload') return 'file';
+        if (this.type === 'file-upload' || this.type === 'signature-pad') return 'file';
```

The existing `valueType` unit test is extended to cover the new mapping. `custom field` tests: **3/3 passing**, lint clean.

## ⚠️ Merge order

**This depends on https://github.com/fleetbase/ember-core/pull/92 and must not land before it.**

`#isPresentForType` in `subject-custom-fields.js` currently accepts only server-expanded JSON for the `file` value type:

```js
return typeof value === 'string' && value.startsWith('{') && value.endsWith('}');
```

The client stages `file:<uuid>`. So on its own, this change would make a just-signed **required** signature field fail validation with "Signature is required" until the record was reloaded. Staying on `'text'` was accidentally masking that. ember-core#92 fixes the presence check — and in doing so also fixes the same latent bug for required `file-upload` fields today.

Part of the signature pad work in https://github.com/fleetbase/ember-ui/pull/156.
