### PR TITLE
fix(api): stop a committed write from reporting "There is no active transaction"

### DIFF
--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -2,6 +2,12 @@
 
 namespace App\Providers;
 
+use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\Events\TransactionBeginning;
+use Illuminate\Database\Events\TransactionCommitting;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
@@ -10,6 +16,18 @@ use Psr\Http\Message\RequestInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
+    /**
+     * Ring buffer of recent statements, kept only while the transaction tripwire is armed.
+     *
+     * @var array<int, string>
+     */
+    protected static array $recentStatements = [];
+
+    /**
+     * Whether a divergence has already been reported on this worker pass.
+     */
+    protected static bool $divergenceReported = false;
+
     /**
      * Register any application services.
      *
@@ -28,6 +46,116 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->configureOutboundHttpLogging();
+        $this->configureTransactionTripwire();
+    }
+
+    /**
+     * Detect the moment Laravel's transaction counter stops agreeing with the MySQL session.
+     *
+     * Laravel decides whether to issue a COMMIT from its own integer counter
+     * (ManagesTransactions::commit(), and the inline twin inside transaction()),
+     * while PDO decides whether a COMMIT is legal from the server's
+     * SERVER_STATUS_IN_TRANS flag. If anything ends the server-side transaction
+     * without going through the Connection - an implicit commit from DDL, or a
+     * second PDO handle aliasing the same persistent MySQL session - the counter
+     * keeps saying "1". Every statement issued since BEGIN is then already
+     * durable, and the eventual commit throws "There is no active transaction",
+     * so the caller reports failure for a write that landed.
+     *
+     * This logs the divergence at the statement that caused it, which is the
+     * only place the culprit is still identifiable.
+     */
+    protected function configureTransactionTripwire(): void
+    {
+        if (!env('DB_TXN_TRIPWIRE_ENABLED', false)) {
+            return;
+        }
+
+        // One report per transaction, not one per worker: a worker serves up to
+        // --max-requests before it recycles, and a single latched flag would hide
+        // every occurrence after the first.
+        Event::listen(TransactionBeginning::class, function (TransactionBeginning $event) {
+            if ($event->connection->transactionLevel() === 1) {
+                static::$divergenceReported = false;
+            }
+        });
+
+        DB::listen(function (QueryExecuted $query) {
+            $this->recordStatement($query->sql);
+
+            if ($query->connection->transactionLevel() < 1) {
+                return;
+            }
+
+            $pdo = $query->connection->getRawPdo();
+
+            if (!$pdo instanceof \PDO || $pdo->inTransaction()) {
+                return;
+            }
+
+            $this->reportTransactionDivergence($query->connection, 'after-statement', $query->sql);
+        });
+
+        // Backstop: the divergence may be caused by something we never see as a
+        // query of ours (another PDO handle on the same session). This catches it
+        // immediately before the doomed COMMIT.
+        Event::listen(TransactionCommitting::class, function (TransactionCommitting $event) {
+            $pdo = $event->connection->getRawPdo();
+
+            if ($pdo instanceof \PDO && !$pdo->inTransaction()) {
+                $this->reportTransactionDivergence($event->connection, 'at-commit', null);
+            }
+        });
+    }
+
+    protected function recordStatement(string $sql): void
+    {
+        static::$recentStatements[] = Str::limit(preg_replace('/\s+/', ' ', $sql), 200);
+
+        if (count(static::$recentStatements) > 25) {
+            array_shift(static::$recentStatements);
+        }
+    }
+
+    protected function reportTransactionDivergence(Connection $connection, string $phase, ?string $sql): void
+    {
+        // One report per worker pass. Re-entrancy guard as well: the CONNECTION_ID()
+        // lookup below is itself a query and would otherwise trip the listener.
+        if (static::$divergenceReported) {
+            return;
+        }
+
+        static::$divergenceReported = true;
+
+        $pdo = $connection->getRawPdo();
+
+        try {
+            $mysqlConnectionId = $pdo instanceof \PDO
+                ? $pdo->query('SELECT CONNECTION_ID()')->fetchColumn()
+                : null;
+        } catch (\Throwable $e) {
+            $mysqlConnectionId = 'unavailable: ' . $e->getMessage();
+        }
+
+        Log::error('[db:txn:divergence] transaction ended outside the Connection', [
+            'phase'               => $phase,
+            'statement'           => $sql === null ? null : Str::limit(preg_replace('/\s+/', ' ', $sql), 300),
+            'connection'          => $connection->getName(),
+            'transaction_level'   => $connection->transactionLevel(),
+            'pdo_object_id'       => $pdo instanceof \PDO ? spl_object_id($pdo) : null,
+            'connection_object_id'=> spl_object_id($connection),
+            'mysql_connection_id' => $mysqlConnectionId,
+            'recent_statements'   => static::$recentStatements,
+            'trace'               => $this->applicationTrace(),
+        ]);
+    }
+
+    protected function applicationTrace(): array
+    {
+        return collect(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 60))
+            ->map(fn ($frame) => ($frame['file'] ?? '?') . ':' . ($frame['line'] ?? '?'))
+            ->values()
+            ->all();
     }
 
     protected function configureOutboundHttpLogging(): void

--- a/api/config/octane.php
+++ b/api/config/octane.php
@@ -105,8 +105,21 @@ return [
         OperationTerminated::class => [
             FlushOnce::class,
             FlushTemporaryContainerInstances::class,
-            DisconnectFromDatabases::class,
-            CollectGarbage::class,    
+            // DisconnectFromDatabases::class,
+            //
+            // Left disabled, as upstream Octane ships it. It was enabled in
+            // a5a5ddb to stop connection-pool exhaustion under load, but it never
+            // did that: the mysql connections are opened with PDO::ATTR_PERSISTENT,
+            // so disconnect() drops the PHP object and leaves the MySQL session
+            // open in PHP's persistent pool. Measured on this stack: 40 concurrent
+            // requests left 17 connections open and still idle minutes later.
+            //
+            // What it did do is churn a fresh PDO handle per request over that one
+            // persistent session, which is how two live handles end up aliasing a
+            // single MySQL transaction. A COMMIT through either handle ends the
+            // transaction for both, and the loser's commit throws "There is no
+            // active transaction" on a write that has already been made durable.
+            CollectGarbage::class,
         ],
 
         WorkerErrorOccurred::class => [

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -4,6 +4,19 @@
 version: "3.8"
 services:
   application:
+    # Pinned so the watcher survives whichever stage built the image.
+    #
+    # docker-compose.yml points `application` at `fleetbase/fleetbase-api:latest`
+    # - the same tag `docker buildx bake release` produces from the app-release
+    # stage (docker-bake.hcl "fleetbase-api"). Whenever that tag already exists
+    # locally, compose runs it instead of building the app-dev stage, and the
+    # app-dev CMD - the only place `--watch` appears - is silently dropped. The
+    # two stages are otherwise byte-identical, so restating the command here is
+    # enough; no dev-specific image is needed.
+    #
+    # Without this the workers never pick up edits under api/, and a change you
+    # made can look like it did not help when it was simply never loaded.
+    command: ["sh", "-c", "php artisan octane:frankenphp --max-requests=1000 --port=8000 --host=0.0.0.0 --watch"]
     environment:
       CONSOLE_HOST: http://localhost:4200
       # Add your environment-specific variables here


### PR DESCRIPTION
## The fault

A write lands in MySQL and the API still answers `422`:

```json
{"errors":["There is no active transaction"]}
```

Confirmed in MySQL: a submit that returned this 422 still moved inventory from 110 to 114. Anyone who retries applies the write twice.

Found on Pallet stock adjustments, but it is **not** Pallet-specific — the logs show it hitting `InternalsOnboardController::createAccount` and the Ledger `PurchaseRateObserver` as well. It is config, and it reaches every module.

## Mechanism

`Connection::commit()` decides whether to issue a COMMIT from **its own `$transactions` counter** ([`ManagesTransactions.php:198-202`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Concerns/ManagesTransactions.php), and the inline twin at `:47-49` that `DB::transaction()` uses). PDO decides whether a COMMIT is **legal** from the MySQL server's `SERVER_STATUS_IN_TRANS` flag. Nothing reconciles them, so the moment anything ends the server-side transaction without going through the `Connection`, every statement since BEGIN is already durable and the COMMIT throws.

core-api opens the mysql connections with `PDO::ATTR_PERSISTENT`, so the MySQL session outlives the PDO object and PHP hands that same session to the next PDO built from the same DSN — including one built while another handle is still alive. Two handles then share one transaction, and a COMMIT through either ends it for both:

```
A conn_id=191316  B conn_id=191316   same underlying session: YES
B->commit() OK
committed rows: 1                                    <-- A's write, committed by B
A->commit() threw: There is no active transaction    <-- the 422
```

`DisconnectFromDatabases` is what churns a fresh PDO handle per request over that one persistent session.

## Two hypotheses that died

- **"A stale `$transactions` counter survives a disconnect."** It cannot. `disconnect()` calls `setPdo(null)`, and `setPdo()` zeroes the counter as its first statement. A disconnect mid-transaction produces a ROLLBACK and a *silently skipped* commit — data lost, no exception. The opposite of this symptom.
- **"`DisconnectFromDatabases` releases connections under load."** It does not, with `ATTR_PERSISTENT` set. Measured here: 40 concurrent requests left **17 MySQL connections open and still idle minutes later**, with the listener enabled.

## Changes

**`api/config/octane.php`** — restores the upstream Octane listener set. `DisconnectFromDatabases` was enabled in a5a5ddb for connection-pool exhaustion under load; it never achieved that, and the steady-state connection count is unchanged with it removed (17 before, 17 after).

**`api/app/Providers/AppServiceProvider.php`** — a tripwire that logs the divergence at the statement that causes it, with the statement, PDO handle id, MySQL session id, recent statements and a backtrace. Inert unless `DB_TXN_TRIPWIRE_ENABLED` is set. This is the only thing that will identify a recurrence while it is still attributable — verified firing against a forced divergence.

**`docker-compose.override.yml.example`** — pins the application command so Octane's `--watch` is actually passed. `--watch` appears only in the app-dev CMD, but compose runs `fleetbase/fleetbase-api:latest` — the tag `docker buildx bake release` builds from **app-release** — whenever it exists locally, so the flag was silently dropped and workers never picked up edits under `api/`. The two stages are identical apart from CMD, so no rebuild is needed. (chokidar is fine and `--poll` is not needed; both were checked.)

## This does not close the hole on its own

The root enabling condition is `PDO::ATTR_PERSISTENT` in **fleetbase/core-api**, fixed in fleetbase/core-api#243. That ships as a separate package pinned here at `^1.6.59`, so it needs a **≥ 1.6.60** release and a bump in `api/composer.json` before the runtime picks it up. Merging this PR alone leaves the aliasing possible.

## Blast radius

`api/config/octane.php` is core API config — it affects every request and every module, not one extension.

- PDO objects now live for the worker's lifetime (`--max-requests=1000`) instead of being rebuilt per request. Connection count is unchanged, because the underlying sessions were already never released.
- `CollectGarbage` is untouched.
- The tripwire adds two event listeners; both return immediately unless a transaction is open, and the whole feature is off unless the env flag is set.

## Not done

Left deliberately, for you to decide:

- No `composer.json` bump for core-api — that waits on the 1.6.60 release.
- The dev stack shares the `fleetbase/fleetbase-api:latest` tag with the release bake, which is what let the `--watch` flag go missing. The command pin makes the image stage irrelevant, so this is a readability hazard rather than a live bug.
- **The live trigger was never caught in production traffic.** The mechanism is proven and reproducible on demand, and the enabling condition is removed, but I did not observe the second COMMIT firing in a real request. The tripwire is what settles that if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)