### PR TITLE
ci: run the storefront capture chain against a paid-capturable cash checkout

### DIFF
--- a/scripts/ci/order-collection-requests.py
+++ b/scripts/ci/order-collection-requests.py
@@ -136,13 +136,21 @@ RUN_LATE = {
         'Cart/Remove item from cart',   # leaves cart A empty, which is the point
 
         # Cart B — priced, checked out, and turned into an order.
+        #
+        # Capture requires a PAID checkout since storefront's Stripe verification
+        # (fleetbase/storefront#95), and this run can never complete a card payment. So
+        # the stripe checkout is only read (status, intent update) and then captured as
+        # an explicit 402 negative contract, while the order the rest of the run needs
+        # comes from a cash pickup checkout, which needs no provider payment.
         'Cart/Retrieve or Create Cart',
         'Cart/Add Item to Cart',
         'Delivery Service Quote/Retrieve a Delivery Service Quote ❗',  # prices the cart
         'Checkout/Before ❗',                    # needs the cart AND {{service_quote_id}}
-        'Checkout/Capture checkout as order',    # needs {{checkout_token}} from Before
-        'Checkout/Get Checkout Status',          # ditto
-        'Checkout/Update Stripe Payment Intent', # needs the cart and the service quote
+        'Checkout/Get Checkout Status',          # needs {{checkout_token}}+{{checkout_id}} from Before
+        'Checkout/Update Stripe Payment Intent', # needs the cart and the service quote, BEFORE capture consumes the cart
+        'Checkout/Capture Stripe checkout without payment',  # 402 contract for the unpaid stripe checkout
+        'Checkout/Before Cash Pickup Checkout',  # needs the cart; sets {{cash_checkout_token}}
+        'Checkout/Capture checkout as order',    # captures the CASH checkout into a real order
         # {{order_id}} is captured by Capture checkout as order — the only request that
         # creates a storefront order.
         'Orders/Complete Order Pickup',


### PR DESCRIPTION
Companion to **fleetbase/postman#55** — together they fix the storefront API contract job that has failed 10 assertions since fleetbase/storefront#94 (customer-update authorization) and fleetbase/storefront#95 (Stripe payment verification before capture) landed in `dev-v0.4.20` (e.g. [this run](https://github.com/fleetbase/storefront/actions/runs/33352040533/job/99367177922)).

## What changed

Resequences the `Fleetbase Storefront API` `RUN_LATE` chain in `scripts/ci/order-collection-requests.py`:

- `Get Checkout Status` and `Update Stripe Payment Intent` move **before** any capture, so they read the stripe checkout and cart while both are untouched.
- `Capture Stripe checkout without payment` (new in fleetbase/postman#55) then asserts the `402` refusal for the unpaid stripe checkout as an explicit negative contract.
- `Before Cash Pickup Checkout` (new in fleetbase/postman#55) initializes a cash pickup checkout — no provider payment, no service quote — and `Capture checkout as order` captures **it**, creating the real order `Complete Order Pickup` and `Get Order Receipt` need.
- The QPay callbacks keep addressing the stripe checkout's `{{checkout_id}}`, unchanged.

## Merge order — this PR second

`RUN_LATE` entries are emitted as `-i` flags without being matched against files first; naming requests the collection doesn't have yet aborts the entire run with 0 requests executed. So **merge fleetbase/postman#55 first**, then this. (Between the two merges, the two new requests run once in the ordinary phase before their variables are set — two transient failures, gone once this lands.)

## Validation

Ran the orderer against the updated collection checkout locally: the chain emits in exactly the intended sequence (`Before ❗ → Get Checkout Status → Update Stripe Payment Intent → Capture Stripe checkout without payment → Before Cash Pickup Checkout → Capture checkout as order → Complete Order Pickup → Get Order Receipt → QPay callbacks`), both new requests resolve to files, no missing-entry warnings, and neither new request leaks into the ordinary phase.