### PR TITLE
ci: seed the driver password-reset code the contract run needs

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -343,6 +343,11 @@ runs:
         #     Update Authenticated Customer is a no-op rename rather than a surprise.
         # verification_code must equal what mint-api-key.php seeded — both read the same
         # action input, so they cannot drift.
+        # driver_password_reset_code is the same seeded value, but it is a SEPARATE
+        # variable because it stands for a different row: DriverController::resetPassword
+        # matches `for=driver_password_reset`, which a driver login code does not satisfy.
+        # Collapsing it into verification_code would work only for as long as both rows
+        # are seeded with the same code.
         # base64_file_data / from_datetime / to_datetime were referenced by requests but
         # set by nothing — see scripts/ci/find-unsourced-variables.py. An unresolved
         # variable is sent literally, so those requests were exercising the API with the
@@ -377,6 +382,7 @@ runs:
           '  --env-var "driver_identity=${DRIVER_IDENTITY}" \' \
           '  --env-var "driver_password=${DRIVER_PASSWORD}" \' \
           '  --env-var "driver_phone=${DRIVER_PHONE}" \' \
+          '  --env-var "driver_password_reset_code=${VERIFICATION_CODE}" \' \
           '  --env-var "device_token=ci-contract-device-token" \' \
           '  --env-var "base64_file_data=iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAbElEQVR42hXNQRUAUQhCUaMYhShGeVGIQhSizB+XXA7ODDtouIHBQ4YOM8suWm5h8ZKl+0CskDiBsIioHhx76LiDw0eO3oN/4FVf+J8h0PduzBqZ8x/bxNQPwgaFy192SGgelC0q13/CJaXlA8Z7WAFXOTbyAAAAAElFTkSuQmCC" \' \
           '  --env-var "from_datetime=2026-01-01T00:00:00Z" \' \

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -274,6 +274,19 @@ try {
     $driverCode->code = $customerCode;
     $driverCode->save();
 
+    // DriverController::resetPassword matches subject_uuid + code + for, and its
+    // `for` is driver_password_reset — a login code will not satisfy it, so the
+    // reset flow needs a row of its own exactly as the customer reset does.
+    \Fleetbase\Models\VerificationCode::withoutGlobalScopes()
+        ->where(['subject_uuid' => $driverUser->uuid, 'for' => 'driver_password_reset'])
+        ->delete();
+    $driverResetCode             = \Fleetbase\Models\VerificationCode::generateFor($driverUser, 'driver_password_reset', false);
+    $driverResetCode->expires_at = \Illuminate\Support\Carbon::now()->addDay();
+    $driverResetCode->status     = 'active';
+    $driverResetCode->save();
+    $driverResetCode->code = $customerCode;
+    $driverResetCode->save();
+
     /* ============================================================
      | SECOND ORGANIZATION (Switch Driver Organization)
      * ============================================================ */


### PR DESCRIPTION
## Why

`DriverController::resetPassword` (added in fleetbase/fleetops#304, merged to `dev-v0.6.61`) matches a
verification code on **subject, value and purpose**, and its purpose is `driver_password_reset`:

```php
VerificationCode::where([
    'subject_uuid' => $user->uuid,
    'code'         => $code,
    'for'          => 'driver_password_reset',
])->where('expires_at', '>', now())->first();
```

The contract run seeds a `driver_login` code for the driver it creates, and that match does not accept
it. So `Reset Driver Password` in fleetbase/postman#53 can only ever return 422 — exactly as the
customer reset would without its own seeded row. The customer flow already seeds one row per
code-checking endpoint for this reason; this adds the driver's missing one.

## What

- `scripts/ci/mint-api-key.php` seeds a `driver_password_reset` row for the seeded driver user,
  mirroring the `driver_login` block directly above it.
- The composite action injects it as `{{driver_password_reset_code}}`.

It carries the same value as `verification_code` but stays a **separate variable**, because it stands
for a different row rather than the same one under another name — collapsing them would work only for
as long as both rows happen to be seeded with the same code. That reasoning is in the comment next to
the existing "must not be tidied up" notes.

## Merge order

This should merge **before or with** fleetbase/postman#53. Until it does, that collection's
`Reset Driver Password` has no code to send.