### PR TITLE
ci(release): accept release/v* branches alongside dev-v*

### DIFF
--- a/.github/workflows/erd.yml
+++ b/.github/workflows/erd.yml
@@ -3,6 +3,7 @@ name: Refresh ERD
 on:
   push:
     branches:
+      - 'release/v*'
       - 'dev-v*'
   workflow_dispatch:
 
@@ -31,7 +32,8 @@ jobs:
     # something this repository can test before merging, and getting it wrong would
     # silently disable manual runs.
     if: >-
-      startsWith(github.ref, 'refs/heads/dev-v') &&
+      (startsWith(github.ref, 'refs/heads/release/v') ||
+       startsWith(github.ref, 'refs/heads/dev-v')) &&
       (github.event_name == 'workflow_dispatch' ||
        (!contains(github.event.head_commit.message, 'automation/erd/') &&
         !startsWith(github.event.head_commit.message, 'Refresh ERD for')))

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,13 +1,17 @@
 name: Release Tag
 
-# Reusable workflow: turn a merged `dev-v*` release branch into a pushed git tag.
+# Reusable workflow: turn a merged release branch into a pushed git tag.
+#
+# Accepts `release/v<semver>` (current convention) and `dev-v<semver>` (legacy, still
+# honoured so branches opened before the rename still release).
 # Called by fleetbase/fleetbase and every module repo:
 #
 #   jobs:
 #     tag:
 #       if: github.event_name == 'workflow_dispatch' ||
 #           (github.event.pull_request.merged == true &&
-#            startsWith(github.event.pull_request.head.ref, 'dev-v'))
+#            (startsWith(github.event.pull_request.head.ref, 'release/v') ||
+#             startsWith(github.event.pull_request.head.ref, 'dev-v')))
 #       uses: fleetbase/fleetbase/.github/workflows/release-tag.yml@main
 #       with:
 #         version-files: composer.json,package.json,extension.json
@@ -143,13 +147,20 @@ jobs:
               exit 1
             fi
 
+            # Two accepted prefixes while the convention moves from dev-v0.0.0 to
+            # release/v0.0.0. Both are honoured deliberately: switching every caller on a
+            # flag day would leave any release branch already open unrecognised, and a
+            # merge that produces no tag and no publish looks exactly like a successful
+            # one. Drop the dev-v arm once no dev-v* branch remains open.
             HEAD_REF="${{ github.event.pull_request.head.ref }}"
-            if [[ "$HEAD_REF" != dev-v* ]]; then
-              echo "::error::Head branch '${HEAD_REF}' is not a dev-v* release branch."
-              exit 1
-            fi
-
-            VERSION="${HEAD_REF#dev-v}"
+            case "$HEAD_REF" in
+              release/v*) VERSION="${HEAD_REF#release/v}" ;;
+              dev-v*)     VERSION="${HEAD_REF#dev-v}" ;;
+              *)
+                echo "::error::Head branch '${HEAD_REF}' is not a release branch (expected release/v<semver> or dev-v<semver>)."
+                exit 1
+                ;;
+            esac
             SHA="${{ github.event.pull_request.merge_commit_sha }}"
             SOURCE="merged PR #${{ github.event.pull_request.number }} (${HEAD_REF})"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
 name: Release Tag
 
-# Tags a release when a `dev-v*` branch is merged to main, and pushes the tag. Delegates
+# Tags a release when a release branch is merged to main, and pushes the tag. Delegates
 # to the reusable workflow in this same repository. Requires org secret
 # _GITHUB_AUTH_TOKEN (inherited); no-ops with a warning until it is set.
 #
 # It pushes the tag and nothing else — create-release.yml, publish-docker-images.yml,
 # build-binaries.yml and discord-announcement.yml all already chain off `push: tags: v*`.
+#
+# Branch convention is `release/v0.0.0`; the legacy `dev-v0.0.0` is still accepted so
+# branches opened before the rename still release.
 #
 # The version is NOT retyped anywhere: it comes from the branch name, and the workflow
 # refuses to tag unless console/package.json and RELEASE.md both agree with it.
@@ -30,7 +33,8 @@ jobs:
   tag:
     if: github.event_name == 'workflow_dispatch' ||
         (github.event.pull_request.merged == true &&
-         startsWith(github.event.pull_request.head.ref, 'dev-v'))
+         (startsWith(github.event.pull_request.head.ref, 'release/v') ||
+          startsWith(github.event.pull_request.head.ref, 'dev-v')))
     uses: ./.github/workflows/release-tag.yml
     with:
       # The root repo has no manifest of its own. The version lives in two places that


### PR DESCRIPTION
Moves the release branch convention to `release/v0.0.0`, and keeps `dev-v0.0.0` working.

## Why both, rather than a cutover

Every module repo calls this reusable workflow from `@main`. A hard switch would leave any release branch **already open** unrecognised — and a merge that produces no tag and no publish looks exactly like a successful one. That is the same silent failure shape as pushing a tag with `GITHUB_TOKEN`; worth avoiding twice.

Drop the `dev-v` arms once no `dev-v*` branch remains open.

## What changed

The version derivation, and nothing else:

```bash
case "$HEAD_REF" in
  release/v*) VERSION="${HEAD_REF#release/v}" ;;
  dev-v*)     VERSION="${HEAD_REF#dev-v}" ;;
  *) echo "::error::... expected release/v<semver> or dev-v<semver>"; exit 1 ;;
esac
```

Everything after it is untouched: semver validation, the manifest checks, the release-notes check, the tag-collision check, and tagging the merge commit rather than `main` at run time.

Verified against the real cases:

| branch | result |
|---|---|
| `release/v0.4.19` | → `v0.4.19` |
| `dev-v1.6.59` | → `v1.6.59` |
| `release/v1.2.3-beta.1` | → `v1.2.3-beta.1` |
| `feature/foo`, `main` | rejected on prefix |
| `release/vX`, `release/v` | rejected on semver |

`release/v*` is a valid GitHub branch filter here — `*` does not match `/`, but it does not need to, since a version contains none.

## Also in this PR

`erd.yml` keys off the release branch too, so it now triggers on `release/v*` as well, and its guard against re-running on the merge commit is extended the same way. It was not part of the original release rollout, so it is worth a second look — there may be other consumers of the old name I have not found. A stale trigger there would simply stop firing, quietly.

Companion PRs update the caller in each module repo. **Merge this one first** — the callers reference `@main`, so their `if` conditions only start matching `release/v*` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)