### PR TITLE
Fix v0.7.57 Docker publish

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -63,7 +63,7 @@ target "app-httpd" {
 target "fleetbase-console" {
   context    = "./console"
   dockerfile = "Dockerfile"
-  platforms  = ["linux/amd64", "linux/arm64"]
+  platforms  = ["linux/amd64"]
 
   tags = notequal("", REGISTRY) ? formatlist(
     "${REGISTRY}/fleetbase-console:%s",


### PR DESCRIPTION
## Summary

Fixes the v0.7.57 Docker publish failure by removing the emulated ARM64 build for the Console image.

The failing release job consistently crashed in the `fleetbase-console` `linux/arm64` target while running `pnpm install --frozen-lockfile` through BuildKit's QEMU emulator:

```text
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

This keeps the API image multi-arch, but publishes the Console image as `linux/amd64` only so the release publish no longer depends on QEMU for the Node/PNPM Console build.

## Changes

- Updated `docker-bake.hcl` so `fleetbase-console` builds only `linux/amd64`.
- Left `fleetbase-api` unchanged as `linux/amd64` and `linux/arm64`.

## Context

- The workflow and Console Dockerfile were unchanged from prior releases.
- The failing path is specifically the emulated ARM64 Console dependency install, not the API PHP extension build.
- The v0.7.57 Docker publish was rerun multiple times and failed consistently at the same QEMU step.

## Validation

- Reviewed the failing Docker publish log.
- Compared the v0.7.57 Docker workflow/bake/Console Dockerfile against the prior successful v0.7.56 publish.
- Ran `git diff --check`.
