### PR TITLE
ci(api): don't write an empty github-oauth token

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -82,7 +82,25 @@ jobs:
           sudo apt-get install -y libzip-dev libgd-dev libgeos-dev libgmp-dev default-mysql-client libicu-dev
 
       - name: Configure Composer auth for GitHub
-        run: composer config --global github-oauth.github.com "${{ secrets._GITHUB_AUTH_TOKEN }}"
+        env:
+          # Falls back to the run's built-in token when _GITHUB_AUTH_TOKEN is not
+          # set (forks, client repos). api/composer.json resolves only public
+          # dists plus registry.fleetbase.io, which does not use github-oauth, so
+          # GITHUB_TOKEN is enough here and lifts the anonymous 60/hr API limit.
+          #
+          # The guard matters: writing an empty value still produces a
+          # `"github.com": ""` entry in auth.json, and Composer then sends an
+          # empty Bearer token and 401s on every dist download
+          # ("Could not authenticate against github.com"). With --no-interaction
+          # it cannot prompt and --prefer-dist disables the source fallback, so
+          # the install dies outright — strictly worse than no entry at all.
+          TOKEN: ${{ secrets._GITHUB_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -n "$TOKEN" ]]; then
+            composer config --global github-oauth.github.com "$TOKEN"
+          else
+            echo "::warning::No GitHub token available; Composer will download dists anonymously."
+          fi
 
       - name: Prepare environment file
         run: |


### PR DESCRIPTION
## Problem

API CI fails at `composer install` on any repo that doesn't have the `_GITHUB_AUTH_TOKEN` secret — e.g. a client fork:

```
Failed to download phpunit/phpunit from dist: Could not authenticate against github.com
Source fallback is disabled. Not trying alternative sources.
Error: Could not authenticate against github.com
```

The auth step wrote the secret unconditionally:

```yaml
run: composer config --global github-oauth.github.com "${{ secrets._GITHUB_AUTH_TOKEN }}"
```

When the secret is absent this renders as `composer config --global github-oauth.github.com ""` (visible in the log as literal `""` rather than the masked `***`). Composer does **not** ignore that — it records:

```json
"github-oauth": { "github.com": "" }
```

Every `api.github.com/repos/.../zipball` request then goes out with an empty Bearer token and 401s. `--no-interaction` means Composer can't prompt for a real token and `--prefer-dist` disables the source fallback, so the install dies. This is strictly worse than having no entry at all: the affected packages (phpunit, predis, spatie/*, symfony mailers) are public and download fine anonymously.

`api.yml` was the only workflow writing this unguarded — `ci.yml`, `gcp-cd.yml`, `install-smoke.yml`, `release-tag.yml` and the rest all check `[[ -n ... ]]` first.

## Change

Guard the write, and fall back to the run's built-in `GITHUB_TOKEN` when `_GITHUB_AUTH_TOKEN` isn't set. `api/composer.json` only adds `registry.fleetbase.io` (which doesn't use `github-oauth`) and the `fleetbase/*` packages it excludes are public, so `GITHUB_TOKEN` is sufficient for this job — and it lifts the anonymous 60/hr API limit to 1000/hr. If neither token exists the step now emits a warning and lets Composer download anonymously rather than poisoning `auth.json`.

## Verification

- Reproduced the mechanism locally against Composer 2.9.2: `composer config --global github-oauth.github.com ""` writes the empty entry.
- YAML parses; the `run` block exercised under `bash -e {0}` semantics with the token both set and empty.