### PR TITLE
v0.7.58

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,12 +2,12 @@
 
 ---
 ## Highlights
-Fleetbase `0.7.58` prepares the root release for the Fleet-Ops nested resource expansion fix. This release keeps Order, Driver, Vehicle, and Fleet API responses safer when parent requests include expanded relations that do not belong to nested Fleet-Ops resources.
+Fleetbase `0.7.58` updates Fleet-Ops to `0.6.64` with nested resource expansion hardening. This release keeps Order, Driver, Vehicle, and Fleet API responses safer when parent requests include expanded relations that do not belong to nested Fleet-Ops resources.
 
 ---
 ## Component Versions
 - `console`: `0.7.58`
-- `fleetops`: pending `0.6.64` publication
+- `fleetops`: `0.6.64`
 
 ---
 ## Fleet-Ops
@@ -20,7 +20,9 @@ Fleetbase `0.7.58` prepares the root release for the Fleet-Ops nested resource e
 ## Console and API Packages
 - Bumped the root Docker image version to `0.7.58`.
 - Bumped Console to `0.7.58`.
-- Fleet-Ops package dependencies and the Fleet-Ops submodule will be updated after Fleet-Ops `0.6.64` is published.
+- Updated Console package dependency for `@fleetbase/fleetops-engine` `^0.6.64`.
+- Updated API package dependency for `fleetbase/fleetops-api` `^0.6.64`.
+- Updated the Fleet-Ops submodule to `v0.6.64`.
 
 ---
 ## Bug Fixes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,58 +1,36 @@
-> v0.7.57 ~ "Fleet-Ops public API expansion and Storefront QPay checkout fixes"
+> v0.7.58 ~ "Fleet-Ops nested resource expansion hardening"
 
 ---
 ## Highlights
-Fleetbase `0.7.57` updates the release stack for Fleet-Ops `0.6.63` and Storefront `0.4.21`. This release expands public Fleet-Ops API contracts for fleets, vehicles, and drivers, restores QPay checkout reliability in Storefront, and aligns the root release branch with the newer `release/v*` publishing flow.
+Fleetbase `0.7.58` prepares the root release for the Fleet-Ops nested resource expansion fix. This release keeps Order, Driver, Vehicle, and Fleet API responses safer when parent requests include expanded relations that do not belong to nested Fleet-Ops resources.
 
 ---
 ## Component Versions
-- `console`: `0.7.57`
-- `fleetops`: `0.6.63`
-- `storefront`: `0.4.21`
+- `console`: `0.7.58`
+- `fleetops`: pending `0.6.64` publication
 
 ---
 ## Fleet-Ops
-- Expanded public Fleet, Vehicle, and Driver API contracts with clearer relationship handling and resource expansion support.
-- Added public relationship helpers for resolving relation UUIDs, public identifiers, request validation, and resource fields.
-- Added membership uniqueness protection for fleet relationship pivots.
-- Fixed null and empty relationship inputs so absent relationships are treated safely instead of raising errors.
-- Fixed retrieve-time expansion mapping where the request object is not injected.
-- Fixed live fleet map settings behavior so tracked settings requests are not mutated unexpectedly.
-- Updated Fleet-Ops release workflows so server, Ember, and Postman checks run correctly on `release/v*` branches.
-- Restored driver vendor names in the drivers list by using the `vendor_name` value already returned by the API.
-- Fixed internal fleet index, edit, and details route expansion by using Fleet model relationship names for fleet relations.
-
----
-## Storefront
-- Restored QPay checkout by fixing callback URL handling and preventing QPay access tokens from being cached past their real expiry.
-- Refactored testing seeders into reusable complete store and network fixtures.
-- Fixed network category relation and owner type behavior for Storefront network models.
-- Updated Storefront release metadata and notes for `0.4.21`.
+- Hardened public Vehicle and Fleet resource expansion so nested resources ignore parent-only relation requests.
+- Fixed Order and Driver responses that include nested vehicles or fleets while the parent request expands fields such as `payload` or `driverAssigned.vehicle`.
+- Preserved direct Fleet, Vehicle, and Driver endpoint expansion behavior while filtering invalid nested relation roots.
+- Added regression coverage for nested Vehicle and Fleet resource serialization.
 
 ---
 ## Console and API Packages
-- Bumped the root Docker image version to `0.7.57`.
-- Bumped Console to `0.7.57`.
-- Updated Console package dependencies for `@fleetbase/fleetops-engine` `^0.6.63` and `@fleetbase/storefront-engine` `^0.4.21`.
-- Updated API package dependencies for `fleetbase/fleetops-api` `^0.6.63` and `fleetbase/storefront-api` `^0.4.21`.
-- Updated the Fleet-Ops and Storefront submodules to their latest release tags.
+- Bumped the root Docker image version to `0.7.58`.
+- Bumped Console to `0.7.58`.
+- Fleet-Ops package dependencies and the Fleet-Ops submodule will be updated after Fleet-Ops `0.6.64` is published.
 
 ---
 ## Bug Fixes
-- Fixed Fleet-Ops public API relationship expansion and null relationship handling.
-- Fixed Fleet-Ops fleet membership duplication safeguards.
-- Fixed Fleet-Ops live fleet map settings mutation behavior.
-- Fixed Fleet-Ops driver vendor names and internal fleet relation expansion requests.
-- Fixed Storefront QPay callback URL and token expiry behavior.
-- Fixed Storefront testing fixture structure for complete store and network scenarios.
+- Fixed nested Fleet-Ops resources reading parent `with` parameters and trying to load unrelated relationships.
+- Fixed serialization failures caused by parent relation names being applied to nested Vehicle and Fleet resources.
 
 ---
 ## API Changes
-- Fleet-Ops public Fleet, Vehicle, and Driver APIs now expose expanded contract support for relationship fields and public identifiers.
-- Fleet-Ops adds fleet membership uniqueness constraints through a release migration.
-- Fleet-Ops internal fleet views now request relation expansions using Fleet model relationship names.
-- Storefront QPay checkout now refreshes access tokens according to their real expiry and uses corrected callback URL wiring.
-- The root release branch now tracks Fleet-Ops `0.6.63` and Storefront `0.4.21` in both Console and API package dependencies.
+- Fleet-Ops public resources now validate requested relation roots against the wrapped model before loading nested expansions.
+- Nested Fleet and Vehicle resources no longer attempt to load parent-only relations from Order or Driver API requests.
 
 ---
 ## Upgrade Steps

--- a/api/composer.json
+++ b/api/composer.json
@@ -22,7 +22,7 @@
         "appstract/laravel-opcache": "^4.0",
         "fleetbase/core-api": "^1.6.60",
         "fleetbase/ai": "^0.0.4",
-        "fleetbase/fleetops-api": "^0.6.63",
+        "fleetbase/fleetops-api": "^0.6.64",
         "fleetbase/registry-bridge": "^0.1.9",
         "fleetbase/customer-portal-api": "^0.0.13",
         "fleetbase/storefront-api": "^0.4.21",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81278a981aaa4c22fc743050548e7455",
+    "content-hash": "87ccd581a406b155afb93ba8dc47cbaa",
     "packages": [
         {
             "name": "appstract/laravel-opcache",
@@ -2552,16 +2552,16 @@
         },
         {
             "name": "fleetbase/fleetops-api",
-            "version": "0.6.63",
+            "version": "0.6.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fleetbase/fleetops.git",
-                "reference": "e3b8cf9833e9d0fb245f5d339a970e3ef0e36985"
+                "reference": "4008beafe7274555de088738d44e2fb33fd2908c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fleetbase/fleetops/zipball/e3b8cf9833e9d0fb245f5d339a970e3ef0e36985",
-                "reference": "e3b8cf9833e9d0fb245f5d339a970e3ef0e36985",
+                "url": "https://api.github.com/repos/fleetbase/fleetops/zipball/4008beafe7274555de088738d44e2fb33fd2908c",
+                "reference": "4008beafe7274555de088738d44e2fb33fd2908c",
                 "shasum": ""
             },
             "require": {
@@ -2638,9 +2638,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fleetbase/fleetops/issues",
-                "source": "https://github.com/fleetbase/fleetops/tree/v0.6.63"
+                "source": "https://github.com/fleetbase/fleetops/tree/v0.6.64"
             },
-            "time": "2026-09-06T05:59:27+00:00"
+            "time": "2026-09-07T12:06:12+00:00"
         },
         {
             "name": "fleetbase/laravel-mysql-spatial",

--- a/console/package.json
+++ b/console/package.json
@@ -41,7 +41,7 @@
         "@fleetbase/ember-core": "^0.3.24",
         "@fleetbase/ember-ui": "^0.3.41",
         "@fleetbase/fleetops-data": "^0.1.40",
-        "@fleetbase/fleetops-engine": "^0.6.63",
+        "@fleetbase/fleetops-engine": "^0.6.64",
         "@fleetbase/iam-engine": "^0.1.11",
         "@fleetbase/leaflet-routing-machine": "^3.2.17",
         "@fleetbase/ledger-engine": "^0.0.10",

--- a/console/package.json
+++ b/console/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/console",
-    "version": "0.7.57",
+    "version": "0.7.58",
     "private": true,
     "description": "Modular logistics and supply chain operating system (LSOS)",
     "repository": "https://github.com/fleetbase/fleetbase",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^0.1.40
         version: 0.1.40(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.29.7)(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26)))(webpack@5.109.2(postcss@8.5.26)))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26))))(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26)))(eslint@8.57.1)(webpack@5.109.2(postcss@8.5.26))
       '@fleetbase/fleetops-engine':
-        specifier: ^0.6.63
-        version: 0.6.63(93581af21a6bd520cd4865ca07cdab92)
+        specifier: ^0.6.64
+        version: 0.6.64(93581af21a6bd520cd4865ca07cdab92)
       '@fleetbase/iam-engine':
         specifier: ^0.1.11
         version: 0.1.11(bffd95f1ee8fa5c6dc085f568b2e0221)
@@ -1586,8 +1586,8 @@ packages:
     resolution: {integrity: sha512-bp4tWaS2cpnitjtmH9hm3T7milwSqgt4j3T/KA8cvsFpbg7p303ADb5CNml5RsribgdBcRYtMsLEFYeYnU9dpg==}
     engines: {node: '>= 18'}
 
-  '@fleetbase/fleetops-engine@0.6.63':
-    resolution: {integrity: sha512-A6SsHRa//6Ue0zd/FSUW2wHHQCarqPCw6d/WWjgk9jdO/MkkZeiqe48f5NW6F03M5WjHVZ8OsQxoZo3yayTcSQ==}
+  '@fleetbase/fleetops-engine@0.6.64':
+    resolution: {integrity: sha512-VzXqATDlXs4C8E3enGXT0dU7G/s63W0i/h/m59qHCQCB3wFbxnAj3MjUSxN1mSqNSRPOS+xqXDjOr/84CBcfZw==}
     engines: {node: '>= 18'}
     peerDependencies:
       ember-engines: ^0.9.0
@@ -11236,7 +11236,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@fleetbase/fleetops-engine@0.6.63(93581af21a6bd520cd4865ca07cdab92)':
+  '@fleetbase/fleetops-engine@0.6.64(93581af21a6bd520cd4865ca07cdab92)':
     dependencies:
       '@babel/core': 7.29.7
       '@fleetbase/ember-core': 0.3.24(@ember/string@3.1.1)(@ember/test-helpers@3.3.1(@babel/core@7.29.7)(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26)))(webpack@5.109.2(postcss@8.5.26)))(ember-resolver@11.0.1(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26))))(ember-source@5.4.1(@babel/core@7.29.7)(@glimmer/component@1.1.2(@babel/core@7.29.7))(rsvp@4.8.5)(webpack@5.109.2(postcss@8.5.26)))(eslint@8.57.1)(webpack@5.109.2(postcss@8.5.26))

--- a/console/pnpm-workspace.yaml
+++ b/console/pnpm-workspace.yaml
@@ -16,4 +16,4 @@ allowBuilds:
   core-js: false
   fsevents: false
 minimumReleaseAgeExclude:
-  - '@fleetbase/fleetops-engine@0.6.63'
+  - '@fleetbase/fleetops-engine@0.6.64'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ ENV QUEUE_CONNECTION=redis
 ENV CADDYFILE_PATH=/fleetbase/Caddyfile
 ENV CONSOLE_PATH=/fleetbase/console
 ENV OCTANE_SERVER=frankenphp
-ENV FLEETBASE_VERSION=0.7.57
+ENV FLEETBASE_VERSION=0.7.58
 
 # Set environment
 ARG ENVIRONMENT=production


### PR DESCRIPTION
## v0.7.58

Release branch for Fleetbase `v0.7.58`, focused on Fleet-Ops `0.6.64` nested resource expansion hardening.

## Component versions

- `console`: `0.7.58`
- `fleetops`: `0.6.64`

## Included PRs

- fleetbase/fleetops#317

Child PRs included through the Fleet-Ops release branch:

- fleetbase/fleetops#316

## Changes

- Bumped `docker/Dockerfile` `FLEETBASE_VERSION` to `0.7.58`.
- Bumped `console/package.json` to `0.7.58`.
- Updated Console package dependency:
  - `@fleetbase/fleetops-engine` `^0.6.64`
- Updated API package dependency:
  - `fleetbase/fleetops-api` `^0.6.64`
- Updated package gitlink:
  - `packages/fleetops` -> `v0.6.64`
- Updated `RELEASE.md` for `v0.7.58`.

## Highlights

- Fleet-Ops hardens nested Vehicle and Fleet resource expansion.
- Order and Driver responses with nested vehicles/fleets no longer try to load parent-only `with` relations on nested resources.
- Direct Fleet, Vehicle, and Driver endpoint expansion behavior is preserved.
- Regression coverage was added in Fleet-Ops for nested resource serialization.

## Validation

- Confirmed Fleet-Ops `v0.6.64` is published.
- Inspected Fleet-Ops #317 and child PR #316 metadata.
- Updated Fleet-Ops Console/API package manifests and lockfiles.
- Updated `packages/fleetops` to the `v0.6.64` tag.
- Verified `RELEASE.md` version and release scope.
- Ran `pnpm install --frozen-lockfile --lockfile-only` in `console`.
- Ran `composer validate --no-check-publish` in `api`.
- Ran `git diff --check`.
