### PR TITLE
ci: seed a published inspection form for the driver inspection contract

### DIFF
--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -153,6 +153,13 @@ runs:
           -e "CI_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}" \
           -e "CI_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}" \
           application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
+        # The inspection link token is the whole credential for the public inspection
+        # routes, and the line below prints every SEEDED_ value to the job log. A mask
+        # only hides what is written after it, so this one is registered first.
+        INSPECTION_LINK_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_TOKEN=[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        if [[ -n "$INSPECTION_LINK_TOKEN" ]]; then
+          echo "::add-mask::$INSPECTION_LINK_TOKEN"
+        fi
         # Always surface what the seed produced, not only when a step later fails.
         #
         # The mint runs one PHP snippet inside a single try, so the FIRST fixture that
@@ -176,6 +183,7 @@ runs:
         NETWORK_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_NETWORK_KEY=network_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         SECONDARY_ORG_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_SECONDARY_ORGANIZATION_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         MULTI_ORG_DRIVER_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_DRIVER_ID=driver_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
+        INSPECTION_LINK_FORM_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_FORM_ID=[A-Za-z0-9_]+' | tail -1 | cut -d= -f2 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -249,6 +257,15 @@ runs:
         fi
         if [[ -n "$MULTI_ORG_DRIVER_ID" ]]; then
           echo "multi_org_driver_id=$MULTI_ORG_DRIVER_ID" >> "$GITHUB_OUTPUT"
+        fi
+        # The public inspection requests authenticate with a link token alone, and a link
+        # can only be minted from the console. Absent only means the FleetOps release on
+        # this stack predates inspection links. The token was masked above.
+        if [[ -n "$INSPECTION_LINK_TOKEN" && -n "$INSPECTION_LINK_FORM_ID" ]]; then
+          echo "inspection_link_token=$INSPECTION_LINK_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "inspection_link_form_id=$INSPECTION_LINK_FORM_ID" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::No inspection link seeded; the public inspection requests will 403."
         fi
         if [[ -n "$PLATFORM_TOKEN" ]]; then
           echo "::add-mask::$PLATFORM_TOKEN"
@@ -345,6 +362,8 @@ runs:
         NETWORK_KEY: ${{ steps.key.outputs.network_key }}
         SECONDARY_ORG_ID: ${{ steps.key.outputs.secondary_organization_id }}
         MULTI_ORG_DRIVER_ID: ${{ steps.key.outputs.multi_org_driver_id }}
+        INSPECTION_LINK_TOKEN: ${{ steps.key.outputs.inspection_link_token }}
+        INSPECTION_LINK_FORM_ID: ${{ steps.key.outputs.inspection_link_form_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
         NAMESPACE: ${{ inputs.namespace }}
@@ -440,6 +459,8 @@ runs:
           '  --env-var "network_key=${NETWORK_KEY}" \' \
           '  --env-var "secondary_organization_id=${SECONDARY_ORG_ID}" \' \
           '  --env-var "multi_org_driver_id=${MULTI_ORG_DRIVER_ID}" \' \
+          '  --env-var "inspection_link_token=${INSPECTION_LINK_TOKEN}" \' \
+          '  --env-var "inspection_link_form_id=${INSPECTION_LINK_FORM_ID}" \' \
           '  --env-var "payment_reference=ci-contract-payment-reference" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"
@@ -565,6 +586,12 @@ runs:
             -e 's/((sk|rk|pk)_(live|test)_)[A-Za-z0-9]+/\1<redacted>/g' \
               "$f"
           done
+          # The inspection link token travels in a query string and a form field, not an
+          # Authorization header, so the scrub above misses it. It is alphanumeric, so it
+          # is safe to use as a pattern as it stands.
+          if [[ -n "${INSPECTION_LINK_TOKEN:-}" ]]; then
+            sed -i "s/${INSPECTION_LINK_TOKEN}/<redacted>/g" "$ansi" "$log"
+          fi
 
           # Read executed/failed out of the reporter's summary table. Each row is
           # "| <label> | <executed> | <failed> |", so match the label plus two numbers

--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -153,18 +153,6 @@ runs:
           -e "CI_STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}" \
           -e "CI_STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}" \
           application php artisan tinker --execute="eval(base64_decode('${CODE}'));" 2>&1 || true)"
-        # The inspection link token is the whole credential for the public inspection
-        # routes, and the line below prints every SEEDED_ value to the job log. A mask
-        # only hides what is written after it, so this one is registered first.
-        INSPECTION_LINK_TOKEN="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_TOKEN=[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
-        if [[ -n "$INSPECTION_LINK_TOKEN" ]]; then
-          echo "::add-mask::$INSPECTION_LINK_TOKEN"
-        fi
-        # The link's PIN is the second half of that credential, so it is masked first too.
-        INSPECTION_LINK_PIN="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_PIN=[0-9]+' | tail -1 | cut -d= -f2 || true)"
-        if [[ -n "$INSPECTION_LINK_PIN" ]]; then
-          echo "::add-mask::$INSPECTION_LINK_PIN"
-        fi
         # Always surface what the seed produced, not only when a step later fails.
         #
         # The mint runs one PHP snippet inside a single try, so the FIRST fixture that
@@ -188,7 +176,6 @@ runs:
         NETWORK_KEY="$(printf '%s\n' "$OUT" | grep -oE 'MINTED_NETWORK_KEY=network_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         SECONDARY_ORG_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_SECONDARY_ORGANIZATION_ID=company_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
         MULTI_ORG_DRIVER_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_DRIVER_ID=driver_[A-Za-z0-9]+' | tail -1 | cut -d= -f2 || true)"
-        INSPECTION_LINK_FORM_ID="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_FORM_ID=[A-Za-z0-9_]+' | tail -1 | cut -d= -f2 || true)"
         if [[ -z "$KEY" ]]; then
           echo "::error::Could not mint an API key from the running stack. Tinker output:"
           printf '%s\n' "$OUT"
@@ -262,17 +249,6 @@ runs:
         fi
         if [[ -n "$MULTI_ORG_DRIVER_ID" ]]; then
           echo "multi_org_driver_id=$MULTI_ORG_DRIVER_ID" >> "$GITHUB_OUTPUT"
-        fi
-        # The public inspection requests authenticate with a link token alone, and a link
-        # can only be minted from the console. Absent only means the FleetOps release on
-        # this stack predates inspection links. The token was masked above.
-        if [[ -n "$INSPECTION_LINK_TOKEN" && -n "$INSPECTION_LINK_FORM_ID" ]]; then
-          echo "inspection_link_token=$INSPECTION_LINK_TOKEN" >> "$GITHUB_OUTPUT"
-          # Empty on a stack from before PINs, whose links ask for none.
-          echo "inspection_link_pin=$INSPECTION_LINK_PIN" >> "$GITHUB_OUTPUT"
-          echo "inspection_link_form_id=$INSPECTION_LINK_FORM_ID" >> "$GITHUB_OUTPUT"
-        else
-          echo "::warning::No inspection link seeded; the public inspection requests will 403."
         fi
         if [[ -n "$PLATFORM_TOKEN" ]]; then
           echo "::add-mask::$PLATFORM_TOKEN"
@@ -369,9 +345,6 @@ runs:
         NETWORK_KEY: ${{ steps.key.outputs.network_key }}
         SECONDARY_ORG_ID: ${{ steps.key.outputs.secondary_organization_id }}
         MULTI_ORG_DRIVER_ID: ${{ steps.key.outputs.multi_org_driver_id }}
-        INSPECTION_LINK_TOKEN: ${{ steps.key.outputs.inspection_link_token }}
-        INSPECTION_LINK_PIN: ${{ steps.key.outputs.inspection_link_pin }}
-        INSPECTION_LINK_FORM_ID: ${{ steps.key.outputs.inspection_link_form_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
         NAMESPACE: ${{ inputs.namespace }}
@@ -467,9 +440,6 @@ runs:
           '  --env-var "network_key=${NETWORK_KEY}" \' \
           '  --env-var "secondary_organization_id=${SECONDARY_ORG_ID}" \' \
           '  --env-var "multi_org_driver_id=${MULTI_ORG_DRIVER_ID}" \' \
-          '  --env-var "inspection_link_token=${INSPECTION_LINK_TOKEN}" \' \
-          '  --env-var "inspection_link_pin=${INSPECTION_LINK_PIN}" \' \
-          '  --env-var "inspection_link_form_id=${INSPECTION_LINK_FORM_ID}" \' \
           '  --env-var "payment_reference=ci-contract-payment-reference" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
           '  "${@:2}"' > "$RUNNER"
@@ -595,18 +565,6 @@ runs:
             -e 's/((sk|rk|pk)_(live|test)_)[A-Za-z0-9]+/\1<redacted>/g' \
               "$f"
           done
-          # The inspection link token travels in a query string and a form field, not an
-          # Authorization header, so the scrub above misses it. It is alphanumeric, so it
-          # is safe to use as a pattern as it stands.
-          if [[ -n "${INSPECTION_LINK_TOKEN:-}" ]]; then
-            sed -i "s/${INSPECTION_LINK_TOKEN}/<redacted>/g" "$ansi" "$log"
-          fi
-          # Its PIN travels in an X-Inspection-Pin header, which that scrub does not
-          # cover either. Six digits can recur elsewhere in a log; redacting those too
-          # costs a little legibility and nothing else.
-          if [[ -n "${INSPECTION_LINK_PIN:-}" ]]; then
-            sed -i "s/${INSPECTION_LINK_PIN}/<redacted>/g" "$ansi" "$log"
-          fi
 
           # Read executed/failed out of the reporter's summary table. Each row is
           # "| <label> | <executed> | <failed> |", so match the label plus two numbers

--- a/.github/actions/postman-contract/action.yml
+++ b/.github/actions/postman-contract/action.yml
@@ -160,6 +160,11 @@ runs:
         if [[ -n "$INSPECTION_LINK_TOKEN" ]]; then
           echo "::add-mask::$INSPECTION_LINK_TOKEN"
         fi
+        # The link's PIN is the second half of that credential, so it is masked first too.
+        INSPECTION_LINK_PIN="$(printf '%s\n' "$OUT" | grep -oE 'SEEDED_INSPECTION_LINK_PIN=[0-9]+' | tail -1 | cut -d= -f2 || true)"
+        if [[ -n "$INSPECTION_LINK_PIN" ]]; then
+          echo "::add-mask::$INSPECTION_LINK_PIN"
+        fi
         # Always surface what the seed produced, not only when a step later fails.
         #
         # The mint runs one PHP snippet inside a single try, so the FIRST fixture that
@@ -263,6 +268,8 @@ runs:
         # this stack predates inspection links. The token was masked above.
         if [[ -n "$INSPECTION_LINK_TOKEN" && -n "$INSPECTION_LINK_FORM_ID" ]]; then
           echo "inspection_link_token=$INSPECTION_LINK_TOKEN" >> "$GITHUB_OUTPUT"
+          # Empty on a stack from before PINs, whose links ask for none.
+          echo "inspection_link_pin=$INSPECTION_LINK_PIN" >> "$GITHUB_OUTPUT"
           echo "inspection_link_form_id=$INSPECTION_LINK_FORM_ID" >> "$GITHUB_OUTPUT"
         else
           echo "::warning::No inspection link seeded; the public inspection requests will 403."
@@ -363,6 +370,7 @@ runs:
         SECONDARY_ORG_ID: ${{ steps.key.outputs.secondary_organization_id }}
         MULTI_ORG_DRIVER_ID: ${{ steps.key.outputs.multi_org_driver_id }}
         INSPECTION_LINK_TOKEN: ${{ steps.key.outputs.inspection_link_token }}
+        INSPECTION_LINK_PIN: ${{ steps.key.outputs.inspection_link_pin }}
         INSPECTION_LINK_FORM_ID: ${{ steps.key.outputs.inspection_link_form_id }}
         COLLECTIONS: ${{ inputs.collections }}
         BASE_URL: ${{ inputs.base-url }}
@@ -460,6 +468,7 @@ runs:
           '  --env-var "secondary_organization_id=${SECONDARY_ORG_ID}" \' \
           '  --env-var "multi_org_driver_id=${MULTI_ORG_DRIVER_ID}" \' \
           '  --env-var "inspection_link_token=${INSPECTION_LINK_TOKEN}" \' \
+          '  --env-var "inspection_link_pin=${INSPECTION_LINK_PIN}" \' \
           '  --env-var "inspection_link_form_id=${INSPECTION_LINK_FORM_ID}" \' \
           '  --env-var "payment_reference=ci-contract-payment-reference" \' \
           '  --env-var "push_token=ci-contract-push-token" \' \
@@ -591,6 +600,12 @@ runs:
           # is safe to use as a pattern as it stands.
           if [[ -n "${INSPECTION_LINK_TOKEN:-}" ]]; then
             sed -i "s/${INSPECTION_LINK_TOKEN}/<redacted>/g" "$ansi" "$log"
+          fi
+          # Its PIN travels in an X-Inspection-Pin header, which that scrub does not
+          # cover either. Six digits can recur elsewhere in a log; redacting those too
+          # costs a little legibility and nothing else.
+          if [[ -n "${INSPECTION_LINK_PIN:-}" ]]; then
+            sed -i "s/${INSPECTION_LINK_PIN}/<redacted>/g" "$ansi" "$log"
           fi
 
           # Read executed/failed out of the reporter's summary table. Each row is

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -323,6 +323,53 @@ try {
     echo 'SEEDED_DRIVER_PHONE=' . $driverPhone . PHP_EOL;
 
     /* ============================================================
+     | INSPECTION FORM (Fleetbase API / Inspections)
+     * ============================================================ */
+
+    // The driver inspection endpoints (fleetops#319, postman#60) list published forms
+    // and submit against one. Forms are authored and published from the console — no
+    // consumable route creates one — so a contract run has to seed it. Organisation-wide
+    // (`subject_uuid` null) so it applies to whatever vehicle the collection creates.
+    // Guarded: the model exists only once the FleetOps release that carries inspections
+    // is installed; earlier stacks skip it and the six requests are the postman run's
+    // problem, not this script's.
+    if (class_exists(\Fleetbase\FleetOps\Models\InspectionForm::class)) {
+        $inspectionForm = \Fleetbase\FleetOps\Models\InspectionForm::withoutGlobalScopes()
+            ->where(['company_uuid' => $company->uuid, 'name' => 'CI Contract Pre-trip'])
+            ->first();
+
+        if (!$inspectionForm) {
+            $inspectionForm = new \Fleetbase\FleetOps\Models\InspectionForm();
+            $inspectionForm->company_uuid    = $company->uuid;
+            $inspectionForm->created_by_uuid = $user->uuid;
+            $inspectionForm->name            = 'CI Contract Pre-trip';
+        }
+
+        // Reasserted on every run: the listing filters on `status=published` AND a
+        // `published_at`, and the submit path counts failures from these two items.
+        $inspectionForm->description  = 'Seeded by the API contract run.';
+        $inspectionForm->type         = 'pre_trip';
+        $inspectionForm->frequency    = 'pre_trip';
+        $inspectionForm->status       = 'published';
+        $inspectionForm->published_at = $inspectionForm->published_at ?? \Illuminate\Support\Carbon::now();
+        $inspectionForm->subject_type = null;
+        $inspectionForm->subject_uuid = null;
+        $inspectionForm->items        = [
+            ['key' => 'brakes', 'label' => 'Brakes', 'category' => 'Brakes', 'required' => true, 'severity' => 'critical'],
+            ['key' => 'lights', 'label' => 'Lights and indicators', 'category' => 'Lights', 'required' => true, 'severity' => 'medium'],
+        ];
+        $inspectionForm->settings     = [
+            'create_issue_on_failure'      => true,
+            'create_work_order_on_failure' => true,
+        ];
+        $inspectionForm->save();
+
+        echo 'SEEDED_INSPECTION_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
+    } else {
+        echo 'SEEDED_INSPECTION_FORM_ID=' . PHP_EOL;
+    }
+
+    /* ============================================================
      | FOOD TRUCK (Storefront)
      * ============================================================ */
 

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -367,80 +367,6 @@ try {
         echo 'SEEDED_INSPECTION_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
 
         /* --------------------------------------------------------
-         | Inspection link (public, tokenised form)
-         * -------------------------------------------------------- */
-
-        // The public inspection requests (Retrieve a Public Inspection Form, Upload a
-        // Public Inspection Photo, Submit a Public Inspection) authenticate with nothing
-        // but a link token. Links are minted from the console, and a public request is
-        // resolved through the token's hash, so the plaintext can only come from here.
-        //
-        // Multi-use and a day long, so the retrieve, the upload and the submit can all
-        // use it in one run. One link per form for the CI user, reused on reruns; the
-        // token is rotated every run, like the platform token above, and used_at cleared
-        // so a reused link never reads as spent.
-        //
-        // Guarded on the `token` column rather than the class alone: the column arrived
-        // after the table, and a stack between the two would throw on insert — which,
-        // inside this single try, would abort every fixture after it.
-        if (class_exists(\Fleetbase\FleetOps\Models\InspectionLink::class)
-            && \Illuminate\Support\Facades\Schema::hasColumn('inspection_links', 'token')) {
-            $inspectionLink = \Fleetbase\FleetOps\Models\InspectionLink::withoutGlobalScopes()
-                ->where([
-                    'company_uuid'         => $company->uuid,
-                    'inspection_form_uuid' => $inspectionForm->uuid,
-                    'created_by_uuid'      => $user->uuid,
-                ])
-                // withoutGlobalScopes() drops the soft-delete scope too, and the public
-                // lookup would never find a trashed link.
-                ->whereNull('deleted_at')
-                ->first();
-
-            if (!$inspectionLink) {
-                $inspectionLink = new \Fleetbase\FleetOps\Models\InspectionLink();
-                $inspectionLink->company_uuid         = $company->uuid;
-                $inspectionLink->inspection_form_uuid = $inspectionForm->uuid;
-                $inspectionLink->created_by_uuid      = $user->uuid;
-            }
-
-            $inspectionLinkToken = \Fleetbase\FleetOps\Models\InspectionLink::generateToken();
-
-            // The seeded driver, so the public read's identity carries a driver and its
-            // "no phone number" assertion has something to check. No vehicle: none has
-            // been seeded yet at this point in the script.
-            $inspectionLink->driver_uuid  = isset($driverRecord) ? $driverRecord->uuid : null;
-            $inspectionLink->vehicle_uuid = null;
-            $inspectionLink->token_hash   = \Fleetbase\FleetOps\Models\InspectionLink::hashToken($inspectionLinkToken);
-            $inspectionLink->token        = $inspectionLinkToken;
-            $inspectionLink->status       = 'active';
-            $inspectionLink->single_use   = false;
-            $inspectionLink->expires_at   = \Illuminate\Support\Carbon::now()->addDay();
-            $inspectionLink->used_at      = null;
-
-            // Links carry a PIN, which the public routes ask for in the X-Inspection-Pin
-            // header. A fresh one every run, which also clears any wrong-PIN count and
-            // lifts a lock left by an earlier run. Guarded like the token: a stack from
-            // before PINs has neither the columns nor setPin(), and its links ask for none.
-            $inspectionLinkPin = '';
-            if (method_exists($inspectionLink, 'setPin')
-                && \Illuminate\Support\Facades\Schema::hasColumn('inspection_links', 'pin_hash')) {
-                $inspectionLinkPin = \Fleetbase\FleetOps\Models\InspectionLink::generatePin();
-                $inspectionLink->setPin($inspectionLinkPin);
-            }
-
-            $inspectionLink->save();
-
-            echo 'SEEDED_INSPECTION_LINK_TOKEN=' . $inspectionLinkToken . PHP_EOL;
-            echo 'SEEDED_INSPECTION_LINK_PIN=' . $inspectionLinkPin . PHP_EOL;
-            echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
-        } else {
-            echo '::warning::Inspection links unavailable; the public inspection requests will 403.' . PHP_EOL;
-            echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
-            echo 'SEEDED_INSPECTION_LINK_PIN=' . PHP_EOL;
-            echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
-        }
-
-        /* --------------------------------------------------------
          | Inspection form field groups (custom-field system)
          * -------------------------------------------------------- */
 
@@ -626,9 +552,6 @@ try {
         }
     } else {
         echo 'SEEDED_INSPECTION_FORM_ID=' . PHP_EOL;
-        echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
-        echo 'SEEDED_INSPECTION_LINK_PIN=' . PHP_EOL;
-        echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
         echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . PHP_EOL;
     }
 

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -367,6 +367,66 @@ try {
         echo 'SEEDED_INSPECTION_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
 
         /* --------------------------------------------------------
+         | Inspection link (public, tokenised form)
+         * -------------------------------------------------------- */
+
+        // The public inspection requests (Retrieve a Public Inspection Form, Upload a
+        // Public Inspection Photo, Submit a Public Inspection) authenticate with nothing
+        // but a link token. Links are minted from the console, and a public request is
+        // resolved through the token's hash, so the plaintext can only come from here.
+        //
+        // Multi-use and a day long, so the retrieve, the upload and the submit can all
+        // use it in one run. One link per form for the CI user, reused on reruns; the
+        // token is rotated every run, like the platform token above, and used_at cleared
+        // so a reused link never reads as spent.
+        //
+        // Guarded on the `token` column rather than the class alone: the column arrived
+        // after the table, and a stack between the two would throw on insert — which,
+        // inside this single try, would abort every fixture after it.
+        if (class_exists(\Fleetbase\FleetOps\Models\InspectionLink::class)
+            && \Illuminate\Support\Facades\Schema::hasColumn('inspection_links', 'token')) {
+            $inspectionLink = \Fleetbase\FleetOps\Models\InspectionLink::withoutGlobalScopes()
+                ->where([
+                    'company_uuid'         => $company->uuid,
+                    'inspection_form_uuid' => $inspectionForm->uuid,
+                    'created_by_uuid'      => $user->uuid,
+                ])
+                // withoutGlobalScopes() drops the soft-delete scope too, and the public
+                // lookup would never find a trashed link.
+                ->whereNull('deleted_at')
+                ->first();
+
+            if (!$inspectionLink) {
+                $inspectionLink = new \Fleetbase\FleetOps\Models\InspectionLink();
+                $inspectionLink->company_uuid         = $company->uuid;
+                $inspectionLink->inspection_form_uuid = $inspectionForm->uuid;
+                $inspectionLink->created_by_uuid      = $user->uuid;
+            }
+
+            $inspectionLinkToken = \Fleetbase\FleetOps\Models\InspectionLink::generateToken();
+
+            // The seeded driver, so the public read's identity carries a driver and its
+            // "no phone number" assertion has something to check. No vehicle: none has
+            // been seeded yet at this point in the script.
+            $inspectionLink->driver_uuid  = isset($driverRecord) ? $driverRecord->uuid : null;
+            $inspectionLink->vehicle_uuid = null;
+            $inspectionLink->token_hash   = \Fleetbase\FleetOps\Models\InspectionLink::hashToken($inspectionLinkToken);
+            $inspectionLink->token        = $inspectionLinkToken;
+            $inspectionLink->status       = 'active';
+            $inspectionLink->single_use   = false;
+            $inspectionLink->expires_at   = \Illuminate\Support\Carbon::now()->addDay();
+            $inspectionLink->used_at      = null;
+            $inspectionLink->save();
+
+            echo 'SEEDED_INSPECTION_LINK_TOKEN=' . $inspectionLinkToken . PHP_EOL;
+            echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
+        } else {
+            echo '::warning::Inspection links unavailable; the public inspection requests will 403.' . PHP_EOL;
+            echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
+            echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
+        }
+
+        /* --------------------------------------------------------
          | Inspection form field groups (custom-field system)
          * -------------------------------------------------------- */
 
@@ -552,6 +612,8 @@ try {
         }
     } else {
         echo 'SEEDED_INSPECTION_FORM_ID=' . PHP_EOL;
+        echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
+        echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
         echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . PHP_EOL;
     }
 

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -416,13 +416,27 @@ try {
             $inspectionLink->single_use   = false;
             $inspectionLink->expires_at   = \Illuminate\Support\Carbon::now()->addDay();
             $inspectionLink->used_at      = null;
+
+            // Links carry a PIN, which the public routes ask for in the X-Inspection-Pin
+            // header. A fresh one every run, which also clears any wrong-PIN count and
+            // lifts a lock left by an earlier run. Guarded like the token: a stack from
+            // before PINs has neither the columns nor setPin(), and its links ask for none.
+            $inspectionLinkPin = '';
+            if (method_exists($inspectionLink, 'setPin')
+                && \Illuminate\Support\Facades\Schema::hasColumn('inspection_links', 'pin_hash')) {
+                $inspectionLinkPin = \Fleetbase\FleetOps\Models\InspectionLink::generatePin();
+                $inspectionLink->setPin($inspectionLinkPin);
+            }
+
             $inspectionLink->save();
 
             echo 'SEEDED_INSPECTION_LINK_TOKEN=' . $inspectionLinkToken . PHP_EOL;
+            echo 'SEEDED_INSPECTION_LINK_PIN=' . $inspectionLinkPin . PHP_EOL;
             echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
         } else {
             echo '::warning::Inspection links unavailable; the public inspection requests will 403.' . PHP_EOL;
             echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
+            echo 'SEEDED_INSPECTION_LINK_PIN=' . PHP_EOL;
             echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
         }
 
@@ -613,6 +627,7 @@ try {
     } else {
         echo 'SEEDED_INSPECTION_FORM_ID=' . PHP_EOL;
         echo 'SEEDED_INSPECTION_LINK_TOKEN=' . PHP_EOL;
+        echo 'SEEDED_INSPECTION_LINK_PIN=' . PHP_EOL;
         echo 'SEEDED_INSPECTION_LINK_FORM_ID=' . PHP_EOL;
         echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . PHP_EOL;
     }

--- a/scripts/ci/mint-api-key.php
+++ b/scripts/ci/mint-api-key.php
@@ -365,8 +365,194 @@ try {
         $inspectionForm->save();
 
         echo 'SEEDED_INSPECTION_FORM_ID=' . $inspectionForm->fresh()->public_id . PHP_EOL;
+
+        /* --------------------------------------------------------
+         | Inspection form field groups (custom-field system)
+         * -------------------------------------------------------- */
+
+        // The second cut of inspections stops treating a form as a flat JSON `items`
+        // list and builds it out of the platform's custom-field system: a form's groups
+        // are Category rows (`for = custom_field_group`, owned by the form) and its
+        // fields are CustomField rows (`for = fleetops_inspection_form`, subject = the
+        // form). `items` above is left in place so a stack on the first cut still has a
+        // submittable form; the groups below are what the second cut reads.
+        //
+        // Guarded twice over. The two constants only exist on the FleetOps release that
+        // carries the second cut, so they are read through `defined()` with the literal
+        // values as the fallback — referencing an undefined class constant is a fatal
+        // error, not a catchable one, and would take the whole seed with it. Category
+        // and CustomField ship with core-api, but they are checked too so this block
+        // degrades the same way the form itself does rather than half-running.
+        $groupFor = defined('\Fleetbase\FleetOps\Models\InspectionForm::GROUP_FOR')
+            ? \Fleetbase\FleetOps\Models\InspectionForm::GROUP_FOR
+            : 'custom_field_group';
+        $fieldFor = defined('\Fleetbase\FleetOps\Models\InspectionForm::FIELD_FOR')
+            ? \Fleetbase\FleetOps\Models\InspectionForm::FIELD_FOR
+            : 'fleetops_inspection_form';
+
+        if (class_exists(\Fleetbase\Models\Category::class) && class_exists(\Fleetbase\Models\CustomField::class)) {
+            // The morph value both sides key on. Taken from the model rather than
+            // hardcoded so a morph map, if one is ever registered, is respected.
+            $formType = $inspectionForm->getMorphClass();
+
+            // Two groups: what the driver walks around and checks, then what they read
+            // off the dash and sign. `grid_size` is how many columns the group renders
+            // its fields in — the checks pair up two-across, the meter and the signature
+            // want the full width.
+            $inspectionGroups = [
+                [
+                    'name'        => 'Exterior and Safety',
+                    'description' => 'Walk-around checks completed before the vehicle moves.',
+                    'order'       => 1,
+                    'meta'        => ['grid_size' => 2],
+                    'fields'      => [
+                        [
+                            'name'      => 'brakes',
+                            'label'     => 'Brakes',
+                            'type'      => 'pass-fail',
+                            'required'  => true,
+                            'order'     => 1,
+                            'help_text' => 'Service and park brake, including air loss on an air-braked unit.',
+                            'meta'      => [
+                                'severity'                => 'critical',
+                                'require_photo_on_fail'   => true,
+                                'require_comment_on_fail' => true,
+                                'unsafe_on_fail'          => true,
+                                'instructions'            => 'Pump the pedal and hold. Fail on any pull, sponginess or audible leak.',
+                            ],
+                        ],
+                        [
+                            'name'      => 'lights',
+                            'label'     => 'Lights and indicators',
+                            'type'      => 'pass-fail',
+                            'required'  => true,
+                            'order'     => 2,
+                            'help_text' => 'Head, tail, brake, hazard and both indicators.',
+                            'meta'      => [
+                                'severity'                => 'medium',
+                                'require_photo_on_fail'   => true,
+                                'require_comment_on_fail' => true,
+                                'unsafe_on_fail'          => false,
+                                'instructions'            => 'Walk the vehicle with the hazards on, then check brake lights with a second person.',
+                            ],
+                        ],
+                        [
+                            'name'      => 'damage_notes',
+                            'label'     => 'Damage or defects noted',
+                            'type'      => 'textarea',
+                            'required'  => false,
+                            'order'     => 3,
+                            'help_text' => 'Anything the checks above do not already cover.',
+                            'meta'      => [],
+                        ],
+                    ],
+                ],
+                [
+                    'name'        => 'Meter and Sign-off',
+                    'description' => 'Readings taken from the cab, then the driver declaration.',
+                    'order'       => 2,
+                    'meta'        => ['grid_size' => 1],
+                    'fields'      => [
+                        [
+                            'name'      => 'odometer',
+                            'label'     => 'Odometer reading',
+                            'type'      => 'number',
+                            'required'  => true,
+                            'order'     => 1,
+                            'help_text' => 'Whole kilometres as shown on the dash.',
+                            // `role: odometer` is what marks this as the meter the
+                            // submission reads back onto the vehicle, rather than just
+                            // another number on the form.
+                            'meta'      => ['unit' => 'km', 'role' => 'odometer'],
+                        ],
+                        [
+                            'name'      => 'driver_signature',
+                            'label'     => 'Driver signature',
+                            'type'      => 'signature',
+                            'required'  => true,
+                            'order'     => 2,
+                            'help_text' => 'I confirm the checks above were carried out and recorded honestly.',
+                            'meta'      => [],
+                        ],
+                    ],
+                ],
+            ];
+
+            $seededGroupIds = [];
+
+            foreach ($inspectionGroups as $groupDefinition) {
+                // Idempotent the same way every other fixture here is: look the row up on
+                // the tuple that identifies it, reassert its attributes, save. A re-run
+                // updates in place instead of stacking a second copy of every group.
+                $group = \Fleetbase\Models\Category::withoutGlobalScopes()
+                    ->where([
+                        'company_uuid' => $company->uuid,
+                        'owner_uuid'   => $inspectionForm->uuid,
+                        'owner_type'   => $formType,
+                        'for'          => $groupFor,
+                        'name'         => $groupDefinition['name'],
+                    ])
+                    ->first();
+
+                if (!$group) {
+                    $group = new \Fleetbase\Models\Category();
+                    $group->company_uuid = $company->uuid;
+                    $group->owner_uuid   = $inspectionForm->uuid;
+                    $group->owner_type   = $formType;
+                    $group->for          = $groupFor;
+                    $group->name         = $groupDefinition['name'];
+                }
+
+                $group->description = $groupDefinition['description'];
+                $group->order       = $groupDefinition['order'];
+                $group->meta        = $groupDefinition['meta'];
+                $group->save();
+
+                $seededGroupIds[] = $group->fresh()->public_id;
+
+                foreach ($groupDefinition['fields'] as $fieldDefinition) {
+                    $field = \Fleetbase\Models\CustomField::withoutGlobalScopes()
+                        ->where([
+                            'company_uuid' => $company->uuid,
+                            'subject_uuid' => $inspectionForm->uuid,
+                            'subject_type' => $formType,
+                            'for'          => $fieldFor,
+                            'name'         => $fieldDefinition['name'],
+                        ])
+                        ->first();
+
+                    if (!$field) {
+                        $field = new \Fleetbase\Models\CustomField();
+                        $field->company_uuid = $company->uuid;
+                        $field->subject_uuid = $inspectionForm->uuid;
+                        $field->subject_type = $formType;
+                        $field->for          = $fieldFor;
+                        $field->name         = $fieldDefinition['name'];
+                    }
+
+                    // Reasserted every run, category_uuid included: a field that was
+                    // seeded into the other group on an earlier revision of this list
+                    // gets moved rather than duplicated.
+                    $field->category_uuid = $group->uuid;
+                    $field->label         = $fieldDefinition['label'];
+                    $field->type          = $fieldDefinition['type'];
+                    $field->required      = $fieldDefinition['required'];
+                    $field->editable      = true;
+                    $field->order         = $fieldDefinition['order'];
+                    $field->help_text     = $fieldDefinition['help_text'];
+                    $field->meta          = $fieldDefinition['meta'];
+                    $field->save();
+                }
+            }
+
+            echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . implode(',', $seededGroupIds) . PHP_EOL;
+        } else {
+            echo '::warning::Custom field models unavailable; inspection form groups skipped.' . PHP_EOL;
+            echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . PHP_EOL;
+        }
     } else {
         echo 'SEEDED_INSPECTION_FORM_ID=' . PHP_EOL;
+        echo 'SEEDED_INSPECTION_FORM_GROUP_IDS=' . PHP_EOL;
     }
 
     /* ============================================================


### PR DESCRIPTION
## What

`scripts/ci/mint-api-key.php` seeds what the driver inspections contract needs:

1. **A published inspection form** for the CI organisation: organisation-wide (`subject_uuid` null), two flat `items` (`brakes`/critical, `lights`/medium), `create_issue_on_failure` and `create_work_order_on_failure` on, `published_at` set, reasserted on every run. Echoes `SEEDED_INSPECTION_FORM_ID=`.
2. **Typed field groups on that form.** fleetops#319's second cut builds a form from the custom-field system, so a form with only `items` is empty under it. The seed adds two groups: walk-around checks at `grid_size` 2, then meter and sign-off at 1. Between them they carry two pass-fail fields with severity and on-fail settings, a free-text note, an odometer number field (unit km, role odometer) and the driver signature. `items` stays, so a stack on the first cut is unaffected.

Every block is guarded, so a stack without the FleetOps release that carries it runs exactly as before:

- the form on `class_exists(InspectionForm::class)`;
- the field groups on `defined()` for the class constants, which only exist on the second cut, plus `class_exists` for `Category` and `CustomField`.

## Why

The inspections API in [fleetops#319](https://github.com/fleetbase/fleetops/pull/319) lists published forms and files against one, and forms are console-authored: no consumable route can create one. So the Postman contract in [postman#60](https://github.com/fleetbase/postman/pull/60) needs one seeded, or its requests answer 404 or 422.

An earlier revision of this PR also seeded a public inspection link, with its token and PIN, and wired them into the `postman-contract` action. Those requests have been dropped from postman#60 because the public link routes serve only the console, so that seed and the action changes were reverted. This PR no longer touches the action.

## Order

fleetops#319, then this, then postman#60.

## Validation

- The script parses under `php -l` with a `<?php` tag prepended; it is a tinker snippet, deliberately tagless.

Not run against a live stack: none carries the fleetops branch yet.

## Noticed, not changed

The mint step echoes every `MINTED_` and `SEEDED_` line before masking any of them, so the minted API key, platform token, storefront key and network key reach the job log unmasked. They belong to the throwaway stack the run creates, so the risk is low, but masking them before the echo would be a small separate change.
